### PR TITLE
bruig: make snackbar errors copyable

### DIFF
--- a/bruig/flutterui/bruig/lib/components/copyable.dart
+++ b/bruig/flutterui/bruig/lib/components/copyable.dart
@@ -7,10 +7,18 @@ import 'package:flutter/services.dart';
 class Copyable extends StatelessWidget {
   final String text;
   final TextStyle textStyle;
-  const Copyable(this.text, this.textStyle, {Key? key}) : super(key: key);
+  final bool showSnackbar;
+  const Copyable(this.text, this.textStyle,
+      {this.showSnackbar = true, Key? key})
+      : super(key: key);
 
   void copy(BuildContext context) {
     Clipboard.setData(ClipboardData(text: text));
+
+    if (!showSnackbar) {
+      return;
+    }
+
     var textMsg = text.substring(0, min(text.length, 36));
     if (textMsg.length < text.length) {
       textMsg += "...";

--- a/bruig/flutterui/bruig/lib/components/snackbars.dart
+++ b/bruig/flutterui/bruig/lib/components/snackbars.dart
@@ -1,13 +1,16 @@
+import 'package:bruig/components/copyable.dart';
 import 'package:flutter/material.dart';
 
 void showErrorSnackbar(BuildContext context, String msg) {
   ScaffoldMessenger.of(context).showSnackBar(SnackBar(
       backgroundColor: Theme.of(context).errorColor,
-      content: Text(msg, style: const TextStyle(color: Color(0xFFE4E3E6)))));
+      content: Copyable(msg, const TextStyle(color: Color(0xFFE4E3E6)),
+          showSnackbar: false)));
 }
 
 void showSuccessSnackbar(BuildContext context, String msg) {
   ScaffoldMessenger.of(context).showSnackBar(SnackBar(
       backgroundColor: Colors.green[300],
-      content: Text(msg, style: const TextStyle(color: Color(0xFFE4E3E6)))));
+      content: Copyable(msg, const TextStyle(color: Color(0xFFE4E3E6)),
+          showSnackbar: false)));
 }


### PR DESCRIPTION
fix #12

needs to add some indicator that text was copied and improve the
coloring when hovering.
