### PR TITLE
multi: make post sub/unsub async

### DIFF
--- a/brclient/commands.go
+++ b/brclient/commands.go
@@ -1192,8 +1192,7 @@ var postCommands = []tuicmd{
 			if err != nil {
 				return err
 			}
-			cw := as.findOrNewChatWindow(uid, args[0])
-			go as.subscribeToPosts(cw)
+			go as.subscribeToPosts(uid)
 			return nil
 		},
 	}, {
@@ -1209,8 +1208,7 @@ var postCommands = []tuicmd{
 			if err != nil {
 				return err
 			}
-			cw := as.findOrNewChatWindow(uid, args[0])
-			go as.unsubscribeToPosts(cw)
+			go as.unsubscribeToPosts(uid)
 			return nil
 		},
 	}, {

--- a/bruig/flutterui/plugin/lib/definitions.dart
+++ b/bruig/flutterui/plugin/lib/definitions.dart
@@ -1238,6 +1238,19 @@ class LocalRenameArgs {
   Map<String, dynamic> toJson() => _$LocalRenameArgsToJson(this);
 }
 
+@JsonSerializable()
+class PostSubscriptionResult extends ChatEvent {
+  final String id;
+  @JsonKey(name: "was_sub_request")
+  final bool wasSubRequest;
+  final String error;
+
+  PostSubscriptionResult(this.id, this.wasSubRequest, this.error)
+      : super(id, "");
+  factory PostSubscriptionResult.fromJson(Map<String, dynamic> json) =>
+      _$PostSubscriptionResultFromJson(json);
+}
+
 mixin NtfStreams {
   StreamController<RemoteUser> ntfAcceptedInvites =
       StreamController<RemoteUser>();
@@ -1456,6 +1469,10 @@ abstract class PluginPlatform {
 
   Future<void> subscribeToPosts(String uid) async {
     await asyncCall(CTSubscribeToPosts, uid);
+  }
+
+  Future<void> unsubscribeToPosts(String uid) async {
+    await asyncCall(CTUnsubscribeToPosts, uid);
   }
 
   Future<void> requestKXReset(String uid) async {
@@ -1877,3 +1894,4 @@ const int NTLNDcrlndStopped = 0x1018;
 const int NTClientStopped = 0x1019;
 const int NTUserPostsList = 0x101a;
 const int NTUserContentList = 0x101b;
+const int NTPostSubscriptionResult = 0x101c;

--- a/bruig/flutterui/plugin/lib/definitions.g.dart
+++ b/bruig/flutterui/plugin/lib/definitions.g.dart
@@ -1248,3 +1248,19 @@ Map<String, dynamic> _$LocalRenameArgsToJson(LocalRenameArgs instance) =>
       'new_name': instance.newName,
       'is_gc': instance.isGC,
     };
+
+PostSubscriptionResult _$PostSubscriptionResultFromJson(
+        Map<String, dynamic> json) =>
+    PostSubscriptionResult(
+      json['id'] as String,
+      json['was_sub_request'] as bool,
+      json['error'] as String,
+    );
+
+Map<String, dynamic> _$PostSubscriptionResultToJson(
+        PostSubscriptionResult instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'was_sub_request': instance.wasSubRequest,
+      'error': instance.error,
+    };

--- a/bruig/flutterui/plugin/lib/desktop.dart
+++ b/bruig/flutterui/plugin/lib/desktop.dart
@@ -261,6 +261,11 @@ mixin BaseDesktopPlatform on NtfStreams {
         ntfChatEvents.add(event);
         break;
 
+      case NTPostSubscriptionResult:
+        var event = PostSubscriptionResult.fromJson(payload);
+        ntfChatEvents.add(event);
+        break;
+
       default:
         print("Received unknown notification ${cmd.toRadixString(16)}");
     }

--- a/bruig/golib/command_handlers.go
+++ b/bruig/golib/command_handlers.go
@@ -263,6 +263,20 @@ func handleInitClient(handle uint32, args InitClient) error {
 			notify(NTTipReceived, v, nil)
 		},
 
+		RemoteSubscriptionChanged: func(user *client.RemoteUser, subscribed bool) {
+			v := PostSubscriptionResult{ID: user.ID(), WasSubRequest: subscribed}
+			notify(NTRemoteSubChanged, v, nil)
+		},
+
+		RemoteSubscriptionError: func(user *client.RemoteUser, wasSubscribing bool, errMsg string) {
+			v := PostSubscriptionResult{
+				ID:            user.ID(),
+				WasSubRequest: wasSubscribing,
+				Error:         errMsg,
+			}
+			notify(NTRemoteSubChanged, v, nil)
+		},
+
 		PostReceived: func(user *client.RemoteUser,
 			summary clientdb.PostSummary, pm rpc.PostMetadata) {
 			notify(NTPostReceived, summary, nil)

--- a/bruig/golib/commands.go
+++ b/bruig/golib/commands.go
@@ -126,6 +126,7 @@ const (
 	NTClientStopped          = 0x1019
 	NTUserPostsList          = 0x101a
 	NTUserContentList        = 0x101b
+	NTRemoteSubChanged       = 0x101c
 )
 
 type cmd struct {

--- a/bruig/golib/definitions.go
+++ b/bruig/golib/definitions.go
@@ -249,3 +249,9 @@ type LocalRenameArgs struct {
 	NewName string             `json:"new_name"`
 	IsGC    bool               `json:"is_gc"`
 }
+
+type PostSubscriptionResult struct {
+	ID            zkidentity.ShortID `json:"id"`
+	WasSubRequest bool               `json:"was_sub_request"`
+	Error         string             `json:"error"`
+}

--- a/client/client.go
+++ b/client/client.go
@@ -147,6 +147,17 @@ type Config struct {
 	// unsubscribed).
 	SubscriptionChanged func(user *RemoteUser, subscribed bool)
 
+	// RemoteSubscriptionChanged is called whenever the local client
+	// receives the result of a {Subscribe,Unsubscribe}ToPosts call. In
+	// other words, it's called whenever the status of a local subscription
+	// to a remote user's posts changes.
+	RemoteSubscriptionChanged func(user *RemoteUser, subscribed bool)
+
+	// RemoteSubscriptionError is called when the local client receives a
+	// reply to a {Subscribe,Unsubscribe}ToPosts call with a remote error
+	// message.
+	RemoteSubscriptionError func(user *RemoteUser, wasSubscribing bool, errMsg string)
+
 	// ContentListReceived is called when the list of content of the user is
 	// received.
 	ContentListReceived func(user *RemoteUser, files []clientdb.RemoteFile, listErr error)

--- a/client/client_kx.go
+++ b/client/client_kx.go
@@ -72,11 +72,8 @@ func (c *Client) takePostKXAction(ru *RemoteUser, act clientdb.PostKXAction) err
 			return err
 		}
 
-		if err := c.SubscribeToPosts(ru.ID()); err != nil {
-			return err
-		}
+		return c.subscribeToPosts(ru.ID(), &pid, true)
 
-		return c.GetUserPost(ru.ID(), pid, true)
 	default:
 		return fmt.Errorf("unknown post-kx action type")
 	}

--- a/client/clientdb/interface.go
+++ b/client/clientdb/interface.go
@@ -299,6 +299,7 @@ var (
 	ServerIDEmptyError      = errors.New("server ID is not known")
 	ErrNotFound             = errors.New("entry not found")
 	ErrAlreadySubscribed    = errors.New("already subscribed")
+	ErrNotSubscribed        = errors.New("not subscribed")
 	ErrPostStatusValidation = errors.New("invalid post status update")
 	ErrAlreadyExists        = errors.New("already exists")
 	ErrDuplicatePostStatus  = errors.New("duplicate post status")

--- a/client/clientdb/posts.go
+++ b/client/clientdb/posts.go
@@ -138,7 +138,7 @@ func (db *DB) UnsubscribeToPosts(tx ReadWriteTx, user UserID) error {
 		ss = append(ss, s)
 	}
 	if !unsubscribed {
-		return fmt.Errorf("not subscribed")
+		return ErrNotSubscribed
 	}
 
 	// If we get here we can write the file back

--- a/rpc/routedrpc.go
+++ b/rpc/routedrpc.go
@@ -948,7 +948,14 @@ const (
 )
 
 // RMPostSubscribe subscribes to new posts from a user.
-type RMPostsSubscribe struct{}
+type RMPostsSubscribe struct {
+	// GetPost is an optional post to send to the client, assuming
+	// subscribing to the posts worked.
+	GetPost *zkidentity.ShortID `json:"get_post,omitempty"`
+
+	// IncludeStatus also sends the post status updates if GetPost != nil.
+	IncludeStatus bool `json:"include_status,omitempty"`
+}
 
 const RMCPostsSubscribe = "postssubscribe"
 


### PR DESCRIPTION
This makes the calls to Subscribe/Unsubscribe to posts async, instead of
sync. This improves the case where the remote user is offline and will
take long to reply to the subcription request.

New events are added to notify the UI about a change in subscrption
status.

Both brclient and bruig are updated to handle the new subscription
system.

Fix #54 fix #68.
