### PR TITLE
client: prevent too large RMs

### DIFF
--- a/brclient/appstate.go
+++ b/brclient/appstate.go
@@ -1984,6 +1984,8 @@ func newAppState(sendMsg func(tea.Msg), lndLogLines *sloglinesbuffer.Buffer,
 		return nil, err
 	}
 
+	rpc.SetLog(logBknd.logger("RRPC"))
+
 	// Initialize DB.
 	db, err := clientdb.New(clientdb.Config{
 		Root:          args.DBRoot,

--- a/client/clientdb/content.go
+++ b/client/clientdb/content.go
@@ -94,6 +94,8 @@ func (db *DB) chunkFile(srcFile, chunkDir string) ([]rpc.FileManifest, []byte, u
 		// Accumulate into global file hasher.
 		fHasher.Write(chunk)
 	}
+	db.log.Debugf("Chunked file %s total size %d into %d chunks of max size %d",
+		srcFile, fsize, len(fm), chunkSize)
 	return fm, fHasher.Sum(nil), size, nil
 }
 

--- a/client/errors.go
+++ b/client/errors.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/companyzero/bisonrelay/client/clientintf"
@@ -11,6 +12,7 @@ var (
 	errClientExiting     = fmt.Errorf("client: %w", clientintf.ErrSubsysExiting)
 	errAlreadyExists     = fmt.Errorf("already exists")
 	errUserBlocked       = fmt.Errorf("user is blocked")
+	errRMTooLarge        = errors.New("RM is too large")
 )
 
 type userNotFoundError struct {

--- a/rpc/log.go
+++ b/rpc/log.go
@@ -1,0 +1,10 @@
+package rpc
+
+import "github.com/decred/slog"
+
+var log slog.Logger = slog.Disabled
+
+// SetLog sets the package-level logger.
+func SetLog(v slog.Logger) {
+	log = v
+}

--- a/rpc/routedrpc.go
+++ b/rpc/routedrpc.go
@@ -332,6 +332,9 @@ func ComposeCompressedRM(from *zkidentity.FullIdentity, rm interface{}, zlibLeve
 		return nil, err
 	}
 
+	log.Debugf("Composed compressed %s: payload size %d, "+
+		"final size %d", h.Command, len(payload), mb.Len())
+
 	return mb.Bytes(), nil
 }
 

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -14,6 +14,7 @@
 package rpc
 
 import (
+	"encoding/base64"
 	"strconv"
 	"time"
 
@@ -267,3 +268,16 @@ var (
 // This command must be acknowledged by the remote side.
 type Ping struct{}
 type Pong struct{}
+
+// EstimateRoutedRMWireSize estimates the final wire size of a compressed RM
+// (with compression set to its lowest value, which effectively disables it).
+func EstimateRoutedRMWireSize(compressedRMSize int) int {
+	// Estimation of the overhead in all the various framings used for a
+	// message encoded by ComposeCompressedRM to be sent on the wire.
+	const overheadEstimate = 512
+
+	// The compressed RM will end up encoded as base64 within a json
+	// message.
+	b64size := base64.StdEncoding.EncodedLen(compressedRMSize)
+	return b64size + overheadEstimate
+}


### PR DESCRIPTION
This prevents RMs that will be too large to send to the server from
entering the RMQ, either the RemoteUser.sendRM or the client sendq
call sites.

The file content subsystem already chunks files appropriately, so that
higher level operation already takes into account the max message size.
Other operations may need additional checks added, to prevent the RM
being created in the first place.

fix #77
