### PR TITLE
bruig: Move user/gc submenus to split pane

### DIFF
--- a/bruig/flutterui/bruig/lib/components/active_chat.dart
+++ b/bruig/flutterui/bruig/lib/components/active_chat.dart
@@ -945,30 +945,3 @@ class _MessagesState extends State<Messages> {
             Event(chat, msgs[index], nick, scrollToBottom, widget.showSubMenu));
   }
 }
-/*
-                
-                Stack(alignment: Alignment.topRight, children: [
-                ListView.builder(
-                  itemCount: chats.subUserMenu.length,
-                  itemBuilder: (context, index) => ListTile(
-                      title: Text(chats.subUserMenu[index].label,
-                          style: const TextStyle(fontSize: 11)),
-                      onTap: () {
-                        chats.subUserMenu[index].onSelected(context, chats);
-                        closeMenus(chats);
-                      }),
-                ),
-                Positioned(
-                    top: 5,
-                    right: 5,
-                    child: Material(
-                        color: selectedBackgroundColor.withOpacity(0),
-                        child: IconButton(
-                            hoverColor: selectedBackgroundColor,
-                            splashRadius: 15,
-                            iconSize: 15,
-                            onPressed: () => closeMenus(chats),
-                            icon: Icon(
-                                color: darkTextColor, Icons.close_outlined)))),
-              ])
-              */

--- a/bruig/flutterui/bruig/lib/components/active_chat.dart
+++ b/bruig/flutterui/bruig/lib/components/active_chat.dart
@@ -279,7 +279,10 @@ class ReceivedSentPM extends StatefulWidget {
   final String nick;
   final int timestamp;
   final ShowSubMenuCB showSubMenu;
-  const ReceivedSentPM(this.evnt, this.nick, this.timestamp, this.showSubMenu,
+  final String id;
+
+  const ReceivedSentPM(
+      this.evnt, this.nick, this.timestamp, this.showSubMenu, this.id,
       {Key? key})
       : super(key: key);
 
@@ -366,7 +369,7 @@ class _ReceivedSentPMState extends State<ReceivedSentPM> {
               padding: const EdgeInsets.all(0),
               tooltip: widget.nick,
               onPressed: () {
-                widget.showSubMenu(widget.nick);
+                widget.showSubMenu(widget.id);
               },
             )),
         Expanded(
@@ -419,8 +422,9 @@ class PMW extends StatelessWidget {
       timestamp =
           evnt.source?.nick == null ? event.timestamp : event.timestamp * 1000;
     }
-    return ReceivedSentPM(
-        evnt, evnt.source?.nick ?? nick, timestamp, showSubMenu);
+
+    return ReceivedSentPM(evnt, evnt.source?.nick ?? nick, timestamp,
+        showSubMenu, evnt.source?.id ?? "");
   }
 }
 
@@ -439,8 +443,8 @@ class GCMW extends StatelessWidget {
       timestamp =
           evnt.source?.nick == null ? event.timestamp : event.timestamp * 1000;
     }
-    return ReceivedSentPM(
-        evnt, evnt.source?.nick ?? nick, timestamp, showSubMenu);
+    return ReceivedSentPM(evnt, evnt.source?.nick ?? nick, timestamp,
+        showSubMenu, evnt.source?.id ?? "");
   }
 }
 

--- a/bruig/flutterui/bruig/lib/components/active_chat.dart
+++ b/bruig/flutterui/bruig/lib/components/active_chat.dart
@@ -81,6 +81,7 @@ class _ActiveChatState extends State<ActiveChat> {
     }
     //editLineFocusNode.requestFocus();
     var theme = Theme.of(context);
+    var textColor = theme.dividerColor;
     var darkTextColor = theme.indicatorColor;
     var selectedBackgroundColor = theme.highlightColor;
     var subMenuBorderColor = theme.canvasColor;
@@ -120,6 +121,12 @@ class _ActiveChatState extends State<ActiveChat> {
                           child: Text(chat.nick[0].toUpperCase(),
                               style: TextStyle(
                                   color: avatarTextColor, fontSize: 75)))),
+                  chat.isGC
+                      ? Text("Group Chat",
+                          style: TextStyle(fontSize: 15, color: textColor))
+                      : Empty(),
+                  Text(chat.nick,
+                      style: TextStyle(fontSize: 15, color: textColor)),
                   ListView.builder(
                     shrinkWrap: true,
                     itemCount: client.activeSubMenu.length,

--- a/bruig/flutterui/bruig/lib/models/client.dart
+++ b/bruig/flutterui/bruig/lib/models/client.dart
@@ -220,7 +220,6 @@ class ClientModel extends ChangeNotifier {
     } else {
       activeSubMenu = subUserMenus[id] ?? [];
     }
-    print("here! $id $isGC $activeSubMenu");
     notifyListeners();
   }
 


### PR DESCRIPTION
Sub user menus (that show the various user/gc actions) are now shown in a split pane with the active chat/messages with that user instead of on top of the gc/user lists themselves.  

This now always us to capture the avatar click to show the info within the active chat. 