### PR TITLE
multi: return generic error on C2S RM payment failures

### DIFF
--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -1,11 +1,19 @@
 package rpc
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 
 	"github.com/companyzero/bisonrelay/ratchet"
 )
+
+// ErrRMInvoicePayment is generated on servers when an RM push fails due
+// to some payment check failure in the invoice.
+//
+// Do not change this message as it's used in plain text across the C2S RPC
+// interface.
+var ErrRMInvoicePayment = errors.New("invoice payment error on RM push")
 
 const errUnpaidSubscriptionRVMsg = "unpaid subscription to RV"
 

--- a/server/session.go
+++ b/server/session.go
@@ -381,10 +381,6 @@ func (z *ZKS) sessionReader(ctx context.Context, sc *sessionContext) error {
 			if err != nil {
 				return fmt.Errorf("unmarshal RouteMessage failed")
 			}
-			err = z.isRMPaid(ctx, &r, sc)
-			if err != nil {
-				return fmt.Errorf("isRMPaid: %v", err)
-			}
 			err = z.handleRouteMessage(ctx, sc.writer, message, r, sc)
 			if err != nil {
 				return fmt.Errorf("handleRouteMessage: %v", err)


### PR DESCRIPTION
This makes the RouteMessage command fail with a generic payment error
on all payment-related failures. This makes it more obvious to the
client that the issue is related to the payment and that it should
attempt to send the payload again after fetching and paying for a new
invoice.

This fixes a possible situation where the message is pushed but not
acked and the client tries to continuously reuse the payment, leading to
connection loops.
