### PR TITLE
bruig: Various chat refinements

### DIFF
--- a/bruig/flutterui/bruig/lib/components/active_chat.dart
+++ b/bruig/flutterui/bruig/lib/components/active_chat.dart
@@ -359,17 +359,17 @@ class _ReceivedSentPMState extends State<ReceivedSentPM> {
 
   @override
   Widget build(BuildContext context) {
-    var prefix = " ";
+    var prefix = "";
     var suffix = "";
     switch (widget.evnt.sentState) {
       case CMS_sending:
-        prefix = "… ";
+        prefix = "…";
         break;
       case CMS_sent:
-        prefix = "✓ ";
+        prefix = "✓";
         break;
       case CMS_errored:
-        prefix = "✗ ";
+        prefix = "✗";
         suffix = "\n\n${widget.evnt.sendError}";
         break;
       default:
@@ -382,7 +382,7 @@ class _ReceivedSentPMState extends State<ReceivedSentPM> {
     var formatter = DateFormat('yyyy-MM-dd HH:mm:ss');
     var date = formatter.format(now);
 
-    var msg = "$prefix${widget.evnt.event.msg}$suffix";
+    var msg = "${widget.evnt.event.msg}$suffix";
     msg = msg.replaceAll("\n",
         "  \n"); // Replace newlines with <space space newline> for proper md render
     var theme = Theme.of(context);
@@ -397,35 +397,33 @@ class _ReceivedSentPMState extends State<ReceivedSentPM> {
     var selectedBackgroundColor = theme.highlightColor;
     var textColor = theme.dividerColor;
 
-    return LayoutBuilder(
-        builder: (BuildContext context, BoxConstraints constraints) {
-      return Column(children: [
-        widget.evnt.firstUnread
-            ? Row(children: [
-                Expanded(
-                    child: Divider(
-                  color: textColor, //color of divider
-                  height: 8, //height spacing of divider
-                  thickness: 1, //thickness of divier line
-                  indent: 5, //spacing at the start of divider
-                  endIndent: 5, //spacing at the end of divider
-                )),
-                Text("Last read posts",
-                    style: TextStyle(fontSize: 9, color: textColor)),
-                Expanded(
-                    child: Divider(
-                  color: textColor, //color of divider
-                  height: 8, //height spacing of divider
-                  thickness: 1, //thickness of divier line
-                  indent: 5, //spacing at the start of divider
-                  endIndent: 5, //spacing at the end of divider
-                )),
-              ])
-            : Empty(),
-        Row(children: [
-          widget.evnt.sameUser
-              ? const SizedBox(width: 28)
-              : Container(
+    return Column(children: [
+      widget.evnt.firstUnread
+          ? Row(children: [
+              Expanded(
+                  child: Divider(
+                color: textColor, //color of divider
+                height: 8, //height spacing of divider
+                thickness: 1, //thickness of divier line
+                indent: 5, //spacing at the start of divider
+                endIndent: 5, //spacing at the end of divider
+              )),
+              Text("Last read posts",
+                  style: TextStyle(fontSize: 9, color: textColor)),
+              Expanded(
+                  child: Divider(
+                color: textColor, //color of divider
+                height: 8, //height spacing of divider
+                thickness: 1, //thickness of divier line
+                indent: 5, //spacing at the start of divider
+                endIndent: 5, //spacing at the end of divider
+              )),
+            ])
+          : const Empty(),
+      widget.evnt.sameUser
+          ? const Empty()
+          : Row(children: [
+              Container(
                   width: 28,
                   margin: const EdgeInsets.only(
                       top: 0, bottom: 0, left: 5, right: 0),
@@ -443,50 +441,47 @@ class _ReceivedSentPMState extends State<ReceivedSentPM> {
                       widget.showSubMenu(widget.id);
                     },
                   )),
+              const SizedBox(width: 10),
+              Text(
+                widget.nick,
+                style: TextStyle(
+                  fontSize: 12,
+                  color: avatarColor, // NAME TEXT COLOR,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ]),
+      //const SizedBox(height: 10),
+      Column(crossAxisAlignment: CrossAxisAlignment.stretch, children: [
+        Row(children: [
+          const SizedBox(width: 13),
+          SizedBox(
+              width: 5,
+              child: Text(
+                prefix,
+                style: TextStyle(
+                    fontSize: 12,
+                    color: hightLightTextColor, // NAME TEXT COLOR,
+                    fontWeight: FontWeight.bold,
+                    fontStyle: FontStyle.italic),
+              )),
+          const SizedBox(width: 24),
+          Provider<DownloadSource>(
+              create: (context) => DownloadSource(sourceID),
+              child: MarkdownArea(msg)),
           Expanded(
-              child: Container(
-            decoration: BoxDecoration(
-                color: bgColor,
-                borderRadius:
-                    const BorderRadius.all(Radius.elliptical(10, 10))),
-            padding: const EdgeInsets.all(5),
-            margin:
-                const EdgeInsets.only(top: 5, bottom: 5, left: 10, right: 10),
-            alignment: Alignment.centerLeft,
-            child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Row(children: [
-                    widget.evnt.sameUser
-                        ? const Empty()
-                        : Text(
-                            widget.nick,
-                            style: TextStyle(
-                                fontSize: 12,
-                                color: hightLightTextColor, // NAME TEXT COLOR,
-                                fontWeight: FontWeight.bold,
-                                fontStyle: FontStyle.italic),
-                          ),
-                    const SizedBox(width: 10),
-                    Expanded(
-                        child: Align(
-                            alignment: Alignment.topRight,
-                            child: Text(
-                              date,
-                              style: TextStyle(
-                                  fontSize: 9,
-                                  color: darkTextColor), // DATE COLOR
-                            )))
-                  ]),
-                  const SizedBox(height: 10),
-                  Provider<DownloadSource>(
-                      create: (context) => DownloadSource(sourceID),
-                      child: MarkdownArea(msg))
-                ]),
-          ))
-        ])
-      ]);
-    });
+              child: Align(
+                  alignment: Alignment.topRight,
+                  child: Text(
+                    date,
+                    style: TextStyle(
+                        fontSize: 9, color: darkTextColor), // DATE COLOR
+                  ))),
+          const SizedBox(width: 10)
+        ]),
+        const SizedBox(height: 5),
+      ])
+    ]);
   }
 }
 

--- a/bruig/flutterui/bruig/lib/components/chats_list.dart
+++ b/bruig/flutterui/bruig/lib/components/chats_list.dart
@@ -56,6 +56,9 @@ class _ChatHeadingWState extends State<_ChatHeadingW> {
     var unreadMessageIconColor = theme.indicatorColor;
     var darkTextColor = theme.indicatorColor;
 
+    // Show 1k+ if unread cound goes about 1000
+    var unreadCount = chat.unreadMsgCount > 1000 ? "1k+" : chat.unreadMsgCount;
+
     Widget? trailing;
     if (chat.active) {
       // Do we want to do any text color changes on active?
@@ -66,7 +69,7 @@ class _ChatHeadingWState extends State<_ChatHeadingW> {
           child: CircleAvatar(
               backgroundColor: unreadMessageIconColor,
               radius: 10,
-              child: Text("${chat.unreadMsgCount}",
+              child: Text("$unreadCount",
                   style: TextStyle(color: hightLightTextColor, fontSize: 10))));
     } else if (chat.unreadEventCount > 0) {
       textColor = hightLightTextColor;

--- a/bruig/flutterui/bruig/lib/components/sidebar.dart
+++ b/bruig/flutterui/bruig/lib/components/sidebar.dart
@@ -169,8 +169,10 @@ class _SidebarState extends State<Sidebar> {
         controller: ctrl,
         items: mainMenu.menus
             .map((e) => SidebarXItem(
-                  icon: e.icon,
                   label: e.label,
+                  iconWidget: e.label == "Chats" && client.hasUnreadChats
+                      ? e.iconNotification
+                      : e.icon,
                   onTap: () => switchScreen(e.routeName),
                 ))
             .toList(),

--- a/bruig/flutterui/bruig/lib/models/client.dart
+++ b/bruig/flutterui/bruig/lib/models/client.dart
@@ -246,6 +246,13 @@ class ClientModel extends ChangeNotifier {
     notifyListeners();
   }
 
+  bool _hasUnreadChats = false;
+  bool get hasUnreadChats => _hasUnreadChats;
+  void set hasUnreadChats(bool b) {
+    _hasUnreadChats = b;
+    notifyListeners();
+  }
+
   final Map<String, List<ChatMenuItem>> _subGCMenus = {};
   UnmodifiableMapView<String, List<ChatMenuItem>> get subGCMenus =>
       UnmodifiableMapView(_subGCMenus);
@@ -299,6 +306,21 @@ class ClientModel extends ChangeNotifier {
     _active?._setActive(false);
     _active = c;
     c?._setActive(true);
+
+    // Check for unreadMessages so we can turn off sidebar notification
+    bool unreadChats = false;
+    for (int i = 0; i < _gcChats.length; i++) {
+      if (_gcChats[i].unreadMsgCount > 0) {
+        unreadChats = true;
+      }
+    }
+
+    for (int i = 0; i < _userChats.length; i++) {
+      if (_userChats[i].unreadMsgCount > 0) {
+        unreadChats = true;
+      }
+    }
+    hasUnreadChats = unreadChats;
     hideSubMenu();
     notifyListeners();
   }
@@ -410,6 +432,9 @@ class ClientModel extends ChangeNotifier {
 
         String gcChatOrder = "";
         for (int i = 0; i < _gcChats.length; i++) {
+          if (_gcChats[i].unreadMsgCount > 0) {
+            hasUnreadChats = true;
+          }
           if (i == _gcChats.length - 1) {
             gcChatOrder += _gcChats[i].nick;
           } else {
@@ -422,6 +447,9 @@ class ClientModel extends ChangeNotifier {
 
         String userChatOrder = "";
         for (int i = 0; i < _userChats.length; i++) {
+          if (_userChats[i].unreadMsgCount > 0) {
+            hasUnreadChats = true;
+          }
           if (i == _userChats.length - 1) {
             userChatOrder += _userChats[i].nick;
           } else {

--- a/bruig/flutterui/bruig/lib/models/client.dart
+++ b/bruig/flutterui/bruig/lib/models/client.dart
@@ -103,7 +103,7 @@ class ChatModel extends ChangeNotifier {
   List<ChatEventModel> _msgs = [];
   UnmodifiableListView<ChatEventModel> get msgs => UnmodifiableListView(_msgs);
   void append(ChatEventModel msg) {
-    if (!_active && _unreadMsgCount == 0) {
+    if (!_active && _unreadMsgCount == 0 && _msgs.isNotEmpty) {
       msg.firstUnread = true;
     }
     if (_msgs.isNotEmpty &&

--- a/bruig/flutterui/bruig/lib/models/menus.dart
+++ b/bruig/flutterui/bruig/lib/models/menus.dart
@@ -22,14 +22,20 @@ class MainMenuItem {
   final String routeName;
   final WidgetBuilder builder;
   final WidgetBuilder titleBuilder;
-  final IconData icon;
+  final Widget? icon;
+  final Widget? iconNotification;
 
-  MainMenuItem(
-      this.label, this.routeName, this.builder, this.titleBuilder, this.icon);
+  MainMenuItem(this.label, this.routeName, this.builder, this.titleBuilder,
+      this.icon, this.iconNotification);
 }
 
-MainMenuItem _emptyMenu = MainMenuItem("", "", (context) => const Text(""),
-    (context) => const Text(""), Icons.question_mark);
+MainMenuItem _emptyMenu = MainMenuItem(
+    "",
+    "",
+    (context) => const Text(""),
+    (context) => const Text(""),
+    const SidebarIcon(Icons.question_mark, false),
+    null);
 
 final List<MainMenuItem> mainMenu = [
   MainMenuItem(
@@ -37,7 +43,8 @@ final List<MainMenuItem> mainMenu = [
     FeedScreen.routeName,
     (context) => const FeedScreen(),
     (context) => const FeedScreenTitle(),
-    Icons.list_alt,
+    const SidebarIcon(Icons.list_alt, false),
+    const SidebarIcon(Icons.new_releases_outlined, true),
   ),
   MainMenuItem(
     "Chats",
@@ -45,21 +52,24 @@ final List<MainMenuItem> mainMenu = [
     (context) => Consumer2<ClientModel, AppNotifications>(
         builder: (context, client, ntfns, child) => ChatsScreen(client, ntfns)),
     (context) => const ChatsScreenTitle(),
-    Icons.chat_bubble_outline,
+    const SidebarIcon(Icons.chat_bubble_outline, false),
+    const SidebarIcon(Icons.new_releases_outlined, true),
   ),
   MainMenuItem(
     "LN Management",
     LNScreen.routeName,
     (context) => const LNScreen(),
     (context) => const LNScreenTitle(),
-    Icons.device_hub,
+    const SidebarIcon(Icons.device_hub, false),
+    const SidebarIcon(Icons.device_hub, false),
   ),
   MainMenuItem(
     "Manage Content",
     ManageContentScreen.routeName,
     (context) => const ManageContentScreen(),
     (context) => const ManageContentScreenTitle(),
-    Icons.file_download,
+    const SidebarIcon(Icons.file_download, false),
+    const SidebarIcon(Icons.file_download, false),
   ),
   MainMenuItem(
     "Payment Stats",
@@ -67,22 +77,27 @@ final List<MainMenuItem> mainMenu = [
     (context) => Consumer<ClientModel>(
         builder: (context, client, child) => PayStatsScreen(client)),
     (context) => const PayStatsScreenTitle(),
-    Icons.wallet_outlined,
+    const SidebarIcon(Icons.wallet_outlined, false),
+    const SidebarIcon(Icons.wallet_outlined, false),
   ),
   MainMenuItem(
-      "Settings",
-      SettingsScreen.routeName,
-      (context) => Consumer<ClientModel>(
-          builder: (context, client, child) => SettingsScreen(client)),
-      (context) => const SettingsScreenTitle(),
-      Icons.settings_rounded),
+    "Settings",
+    SettingsScreen.routeName,
+    (context) => Consumer<ClientModel>(
+        builder: (context, client, child) => SettingsScreen(client)),
+    (context) => const SettingsScreenTitle(),
+    const SidebarIcon(Icons.settings_rounded, false),
+    const SidebarIcon(Icons.settings_rounded, false),
+  ),
   MainMenuItem(
-      "Logs",
-      LogScreen.routeName,
-      (context) =>
-          Consumer<LogModel>(builder: (context, log, child) => LogScreen(log)),
-      (context) => const LogScreenTitle(),
-      Icons.list_rounded),
+    "Logs",
+    LogScreen.routeName,
+    (context) =>
+        Consumer<LogModel>(builder: (context, log, child) => LogScreen(log)),
+    (context) => const LogScreenTitle(),
+    const SidebarIcon(Icons.list_rounded, false),
+    const SidebarIcon(Icons.list_rounded, false),
+  ),
 ];
 
 class MainMenuModel extends ChangeNotifier {
@@ -218,4 +233,19 @@ List<ChatMenuItem> buildGCMenu(ChatModel chat) {
       },
     ),
   ];
+}
+
+class SidebarIcon extends StatelessWidget {
+  final IconData icon;
+  final bool alert;
+  const SidebarIcon(this.icon, this.alert, {Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    if (alert) {
+      return Icon(icon, color: Colors.amber);
+    } else {
+      return Icon(icon);
+    }
+  }
 }

--- a/bruig/flutterui/bruig/pubspec.lock
+++ b/bruig/flutterui/bruig/pubspec.lock
@@ -760,10 +760,10 @@ packages:
     dependency: "direct main"
     description:
       name: window_manager
-      sha256: d812d3189d23465d2e94baa2505a4462b46dde4939012ff370711c6897d747ae
+      sha256: "492806c69879f0d28e95472bbe5e8d5940ac8c6e99cc07052fe14946974555ba"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.9"
+    version: "0.3.1"
   window_size:
     dependency: "direct main"
     description:

--- a/bruig/flutterui/bruig/pubspec.yaml
+++ b/bruig/flutterui/bruig/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   ini: ^2.1.0
   args: ^2.3.0
   tuple: ^2.0.0
-  window_manager: ^0.2.5
+  window_manager: ^0.3.1
   shared_preferences: ^2.0.15
   intl: ^0.17.0
   sidebarx: ^0.12.0


### PR DESCRIPTION
This PR attends to the following issues:
- Bumps windows_manager dep to avoid a Seg fault on close.
- Adds sidebar notification for new chat messages.  
- Changes chat message alignments from @davecgh feedback.
- Change notification counter to max out at "1k+" when the unread count is over 1000.
- Avoid adding Last Read Post divider when there are no previous messages in the chat.