### PR TITLE
bruig: show file type icon and open file on click

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ brclient/brclient
 server/internal/frpgdb/cmd/frdbsim/frdbsim
 server.crt
 build/
+.vscode
+*.DS_Store

--- a/bruig/flutterui/bruig/lib/components/active_chat.dart
+++ b/bruig/flutterui/bruig/lib/components/active_chat.dart
@@ -20,6 +20,8 @@ import 'package:provider/provider.dart';
 import 'package:bruig/components/profile.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:bruig/components/empty_widget.dart';
+import 'package:open_filex/open_filex.dart';
+import 'package:file_icon/file_icon.dart';
 
 class ActiveChat extends StatefulWidget {
   final ClientModel client;
@@ -869,17 +871,37 @@ class FileDownloadedEventW extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // TODO: add button to open file.
     var theme = Theme.of(context);
     var textColor = theme.dividerColor;
     var backgroundColor = theme.highlightColor;
     return ServerEvent(
-        child: Container(
-            decoration: BoxDecoration(
-                color: backgroundColor,
-                borderRadius: const BorderRadius.all(Radius.circular(5))),
-            child: SelectableText("Downloaded file ${event.diskPath}",
-                style: TextStyle(fontSize: 9, color: textColor))));
+      child: Container(
+        padding: const EdgeInsets.all(0),
+        decoration: BoxDecoration(
+          color: backgroundColor,
+          borderRadius: const BorderRadius.all(Radius.circular(5)),
+        ),
+        child: Row(
+          children: [
+            Material(
+              color: backgroundColor,
+              child: IconButton(
+                onPressed: () {
+                  OpenFilex.open(event.diskPath);
+                },
+                splashRadius: 20,
+                icon: FileIcon(event.diskPath, size: 24),
+              ),
+            ),
+            const SizedBox(width: 10),
+            SelectableText(
+              "Downloaded file ${event.diskPath}",
+              style: TextStyle(fontSize: 9, color: textColor),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }
 

--- a/bruig/flutterui/bruig/pubspec.lock
+++ b/bruig/flutterui/bruig/pubspec.lock
@@ -145,6 +145,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.4"
+  file_icon:
+    dependency: "direct main"
+    description:
+      name: file_icon
+      sha256: c46b6c24d9595d18995758b90722865baeda407f56308eadd757e1ab913f50a1
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   file_picker:
     dependency: "direct main"
     description:
@@ -343,6 +351,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  open_filex:
+    dependency: "direct main"
+    description:
+      name: open_filex
+      sha256: "854aefd72dfd74219dc8c8d1767c34ec1eae64b8399a5be317bddb1ec2108915"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.2"
   package_config:
     dependency: transitive
     description:

--- a/bruig/flutterui/bruig/pubspec.yaml
+++ b/bruig/flutterui/bruig/pubspec.yaml
@@ -46,7 +46,9 @@ dependencies:
   url_launcher: ^6.1.6
   msix: ^3.6.3
   qr_flutter: ^4.0.0
+  file_icon: ^1.0.0
   package_info_plus: ^3.0.3
+  open_filex: ^4.3.2
 
 msix_config:
   display_name: Bison Relay GUI


### PR DESCRIPTION
Preview:

<img width="916" alt="Screen Shot 2023-03-30 at 13 47 25" src="https://user-images.githubusercontent.com/13955303/228981405-479f0050-823b-4c31-9d64-d4f6566f4596.png">

Clicking the icon will launch the file.

Closes https://github.com/companyzero/bisonrelay/issues/32