### PR TITLE
server: accept RVs to mark paid but not subscribe

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -111,6 +111,7 @@ type RouteMessageReply struct {
 type SubscribeRoutedMessages struct {
 	AddRendezvous []ratchet.RVPoint // Add to subscribed RVs
 	DelRendezvous []ratchet.RVPoint // Del from subscribed RVs
+	MarkPaid      []ratchet.RVPoint // Mark paid but do not subscribe
 }
 
 type SubscribeRoutedMessagesReply struct {

--- a/server/svrpayments.go
+++ b/server/svrpayments.go
@@ -400,7 +400,8 @@ func (z *ZKS) areSubsPaid(ctx context.Context, r *rpc.SubscribeRoutedMessages, s
 	}
 
 	// Store in DB the new unpaid items.
-	for _, rv := range r.AddRendezvous {
+	needsPay := append(r.AddRendezvous, r.MarkPaid...)
+	for _, rv := range needsPay {
 		if paid, err := z.db.IsSubscriptionPaid(ctx, rv); err != nil {
 			return err
 		} else if paid {


### PR DESCRIPTION
This commit adds a feature in the server that allows clients to mark some RVs as paid, but do not actually subscribe to them. This allows prepayment for RV subscription for third parties.
