### PR TITLE
brclient: fix inbound cert loading

### DIFF
--- a/brclient/lnrequestrecv.go
+++ b/brclient/lnrequestrecv.go
@@ -54,7 +54,9 @@ func (pw *lnRequestRecvWindow) request() {
 		server = pw.form.inputs[1].(*textInputHelper).Value()
 		certPath := pw.form.inputs[2].(*textInputHelper).Value()
 
-		cert, pw.requestErr = os.ReadFile(certPath)
+		if certPath != "" {
+			cert, pw.requestErr = os.ReadFile(certPath)
+		}
 	} else if pw.as.network == "mainnet" {
 		server = lp0Server
 		cert = []byte(lp0Cert)


### PR DESCRIPTION
This prevents attempting to load a TLS cert file when the field is empty
in manual mode.
