### PR TITLE
bruig: Feed notifications

### DIFF
--- a/bruig/flutterui/bruig/lib/components/sidebar.dart
+++ b/bruig/flutterui/bruig/lib/components/sidebar.dart
@@ -1,5 +1,6 @@
 import 'package:bruig/components/app_notifications.dart';
 import 'package:bruig/models/client.dart';
+import 'package:bruig/models/feed.dart';
 import 'package:bruig/models/menus.dart';
 import 'package:bruig/models/notifications.dart';
 import 'package:flutter/material.dart';
@@ -12,8 +13,10 @@ class Sidebar extends StatefulWidget {
   final MainMenuModel mainMenu;
   final AppNotifications ntfns;
   final GlobalKey<NavigatorState> navKey;
+  final FeedModel feed;
 
-  const Sidebar(this.client, this.mainMenu, this.ntfns, this.navKey, {Key? key})
+  const Sidebar(this.client, this.mainMenu, this.ntfns, this.navKey, this.feed,
+      {Key? key})
       : super(key: key);
 
   @override
@@ -26,6 +29,7 @@ class _SidebarState extends State<Sidebar> {
   ServerSessionState connState = ServerSessionState.empty();
   SidebarXController ctrl =
       SidebarXController(selectedIndex: 0, extended: true);
+  FeedModel get feed => widget.feed;
 
   void clientUpdated() async {
     setState(() {
@@ -170,7 +174,8 @@ class _SidebarState extends State<Sidebar> {
         items: mainMenu.menus
             .map((e) => SidebarXItem(
                   label: e.label,
-                  iconWidget: e.label == "Chats" && client.hasUnreadChats
+                  iconWidget: (e.label == "Chats" && client.hasUnreadChats) ||
+                          (e.label == "News Feed" && feed.hasUnreadPosts)
                       ? e.iconNotification
                       : e.icon,
                   onTap: () => switchScreen(e.routeName),

--- a/bruig/flutterui/bruig/lib/components/sidebar.dart
+++ b/bruig/flutterui/bruig/lib/components/sidebar.dart
@@ -31,6 +31,10 @@ class _SidebarState extends State<Sidebar> {
       SidebarXController(selectedIndex: 0, extended: true);
   FeedModel get feed => widget.feed;
 
+  void feedUpdated() async {
+    setState(() {});
+  }
+
   void clientUpdated() async {
     setState(() {
       connState = client.connState;
@@ -51,15 +55,18 @@ class _SidebarState extends State<Sidebar> {
   void initState() {
     super.initState();
     clientUpdated();
+    feed.addListener(feedUpdated);
     client.addListener(clientUpdated);
     mainMenu.addListener(menuUpdated);
   }
 
   @override
   void didUpdateWidget(Sidebar oldWidget) {
+    oldWidget.feed.removeListener(feedUpdated);
     oldWidget.client.removeListener(clientUpdated);
     oldWidget.mainMenu.removeListener(menuUpdated);
     super.didUpdateWidget(oldWidget);
+    feed.addListener(feedUpdated);
     client.addListener(clientUpdated);
     mainMenu.addListener(menuUpdated);
   }
@@ -175,7 +182,7 @@ class _SidebarState extends State<Sidebar> {
             .map((e) => SidebarXItem(
                   label: e.label,
                   iconWidget: (e.label == "Chats" && client.hasUnreadChats) ||
-                          (e.label == "News Feed" && feed.hasUnreadPosts)
+                          (e.label == "News Feed" && feed.unreadPostsComments)
                       ? e.iconNotification
                       : e.icon,
                   onTap: () => switchScreen(e.routeName),

--- a/bruig/flutterui/bruig/lib/main.dart
+++ b/bruig/flutterui/bruig/lib/main.dart
@@ -315,12 +315,12 @@ class _AppState extends State<App> with WindowListener {
                 if (settings.name!.startsWith(OverviewScreen.routeName)) {
                   var initialRoute =
                       settings.name!.substring(OverviewScreen.routeName.length);
-                  page = Consumer4<DownloadsModel, ClientModel,
-                          AppNotifications, MainMenuModel>(
-                      builder:
-                          (context, down, client, ntfns, mainMenu, child) =>
-                              OverviewScreen(
-                                  down, client, ntfns, initialRoute, mainMenu));
+                  page = Consumer5<DownloadsModel, ClientModel,
+                          AppNotifications, MainMenuModel, FeedModel>(
+                      builder: (context, down, client, ntfns, mainMenu, feed,
+                              child) =>
+                          OverviewScreen(down, client, ntfns, initialRoute,
+                              mainMenu, feed));
                 } else if (settings.name!
                     .startsWith(NeedsOutChannelScreen.routeName)) {
                   page = Consumer2<AppNotifications, ClientModel>(

--- a/bruig/flutterui/bruig/lib/models/feed.dart
+++ b/bruig/flutterui/bruig/lib/models/feed.dart
@@ -35,6 +35,13 @@ class FeedPostModel extends ChangeNotifier {
 
   String content = "";
 
+  bool _hasUnreadComments = false;
+  bool get hasUnreadComments => _hasUnreadComments;
+  void set hasUnreadComments(bool b) {
+    _hasUnreadComments = b;
+    notifyListeners();
+  }
+
   Future<void> readPost() async {
     var pm = await Golib.readPost(summ.from, summ.id);
     content = pm.attributes[RMPMain] ?? "";
@@ -161,6 +168,13 @@ class FeedModel extends ChangeNotifier {
   List<FeedPostModel> _posts = [];
   Iterable<FeedPostModel> get posts => UnmodifiableListView(_posts);
 
+  bool _hasUnreadPosts = false;
+  bool get hasUnreadPosts => _hasUnreadPosts;
+  void set hasUnreadPosts(bool b) {
+    _hasUnreadPosts = b;
+    notifyListeners();
+  }
+
   void _handleFeedPosts() async {
     // List existing posts before listening for new posts.
     var oldPosts = await Golib.listPosts();
@@ -174,6 +188,7 @@ class FeedModel extends ChangeNotifier {
     await for (var msg in stream) {
       // Add at the start of the feed so it appears at the top of the feed page.
       _posts.insert(0, FeedPostModel(msg));
+      hasUnreadPosts = true;
 
       // Handle posts that replace a previously relayed post: the client removes
       // the relayed post in favor of the one by the author, so remove such posts

--- a/bruig/flutterui/bruig/lib/screens/feed/feed_posts.dart
+++ b/bruig/flutterui/bruig/lib/screens/feed/feed_posts.dart
@@ -164,9 +164,23 @@ class _FeedPostWState extends State<FeedPostW> {
           ]),
           const SizedBox(height: 5),
           Row(children: [
-            unReadPost ? Expanded(child: Text("Unread Post!")) : Empty(),
+            unReadPost
+                ? Expanded(
+                    child: Text("New Post",
+                        style: TextStyle(
+                          fontStyle: FontStyle.italic,
+                          fontSize: 12,
+                          color: hightLightTextColor,
+                        )))
+                : Empty(),
             hasUnreadComments
-                ? Expanded(child: Text("Unread Comments!"))
+                ? Expanded(
+                    child: Text("New Comments",
+                        style: TextStyle(
+                          fontStyle: FontStyle.italic,
+                          fontSize: 12,
+                          color: hightLightTextColor,
+                        )))
                 : Empty(),
             Expanded(
                 child: Align(

--- a/bruig/flutterui/bruig/lib/screens/feed/feed_posts.dart
+++ b/bruig/flutterui/bruig/lib/screens/feed/feed_posts.dart
@@ -7,8 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:crypto/crypto.dart';
 import 'package:provider/provider.dart';
 import 'package:bruig/components/md_elements.dart';
-import 'package:golib_plugin/definitions.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:bruig/components/empty_widget.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:bruig/components/user_context_menu.dart';
 
@@ -22,13 +21,14 @@ Color colorFromNick(String nick) {
 }
 
 class FeedPostW extends StatefulWidget {
+  final FeedModel feed;
   final FeedPostModel post;
   final ChatModel? author;
   final ChatModel? from;
   final ClientModel client;
   final Function onTabChange;
-  const FeedPostW(
-      this.post, this.author, this.from, this.client, this.onTabChange,
+  const FeedPostW(this.feed, this.post, this.author, this.from, this.client,
+      this.onTabChange,
       {Key? key})
       : super(key: key);
 
@@ -37,7 +37,10 @@ class FeedPostW extends StatefulWidget {
 }
 
 class _FeedPostWState extends State<FeedPostW> {
+  FeedModel get feed => widget.feed;
+  FeedPostModel get post => widget.post;
   showContent(BuildContext context) {
+    feed.active = post;
     widget.onTabChange(0, PostContentScreenArgs(widget.post));
   }
 
@@ -64,6 +67,8 @@ class _FeedPostWState extends State<FeedPostW> {
 
   @override
   Widget build(BuildContext context) {
+    var hasUnreadComments = post.hasUnreadComments;
+    var unReadPost = post.unreadPost;
     var authorNick = widget.author?.nick ?? "";
     var authorID = widget.post.summ.authorID;
     var mine = authorID == widget.client.publicID;
@@ -159,6 +164,10 @@ class _FeedPostWState extends State<FeedPostW> {
           ]),
           const SizedBox(height: 5),
           Row(children: [
+            unReadPost ? Expanded(child: Text("Unread Post!")) : Empty(),
+            hasUnreadComments
+                ? Expanded(child: Text("Unread Comments!"))
+                : Empty(),
             Expanded(
                 child: Align(
                     alignment: Alignment.centerRight,
@@ -202,14 +211,6 @@ class _FeedPostsState extends State<FeedPosts> {
   }
 
   @override
-  void initState() {
-    super.initState();
-    setState(() {
-      widget.feed.hasUnreadPosts = false;
-    });
-  }
-
-  @override
   void didUpdateWidget(FeedPosts oldWidget) {
     super.didUpdateWidget(oldWidget);
     oldWidget.feed.removeListener(feedChanged);
@@ -242,8 +243,8 @@ class _FeedPostsState extends State<FeedPosts> {
             var post = posts.elementAt(index);
             var author = widget.client.getExistingChat(post.summ.authorID);
             var from = widget.client.getExistingChat(post.summ.from);
-            return FeedPostW(
-                post, author, from, widget.client, widget.tabChange);
+            return FeedPostW(widget.feed, post, author, from, widget.client,
+                widget.tabChange);
           }),
     );
   }

--- a/bruig/flutterui/bruig/lib/screens/feed/feed_posts.dart
+++ b/bruig/flutterui/bruig/lib/screens/feed/feed_posts.dart
@@ -202,6 +202,14 @@ class _FeedPostsState extends State<FeedPosts> {
   }
 
   @override
+  void initState() {
+    super.initState();
+    setState(() {
+      widget.feed.hasUnreadPosts = false;
+    });
+  }
+
+  @override
   void didUpdateWidget(FeedPosts oldWidget) {
     super.didUpdateWidget(oldWidget);
     oldWidget.feed.removeListener(feedChanged);

--- a/bruig/flutterui/bruig/lib/screens/feed/post_content.dart
+++ b/bruig/flutterui/bruig/lib/screens/feed/post_content.dart
@@ -137,6 +137,7 @@ class _CommentWState extends State<_CommentW> {
     var mine = widget.comment.uid == widget.client.publicID;
     var kxing = widget.client.requestedMediateID(widget.comment.uid);
 
+    var unreadComment = widget.comment.unreadComment;
     var theme = Theme.of(context);
     var hightLightTextColor = theme.dividerColor;
     var textColor = theme.focusColor;
@@ -220,7 +221,7 @@ class _CommentWState extends State<_CommentW> {
           Row(
             children: [
               Expanded(
-                child: MarkdownArea(widget.comment.comment, false),
+                child: MarkdownArea(widget.comment.comment, unreadComment),
               ),
             ],
           ),
@@ -272,7 +273,7 @@ class _PostContentScreenForArgsState extends State<_PostContentScreenForArgs> {
 
     try {
       await widget.args.post.readPost();
-      await widget.args.post.readComments();
+      //await widget.args.post.readComments();
 
       bool newIsKxSearching = false;
       var summ = widget.args.post.summ;
@@ -304,7 +305,7 @@ class _PostContentScreenForArgsState extends State<_PostContentScreenForArgs> {
       if (post != null) {
         (() async {
           await post.readPost();
-          await post.readComments();
+          //await post.readComments();
           widget.tabChange(0, PostContentScreenArgs(post));
         })();
       }
@@ -376,6 +377,11 @@ class _PostContentScreenForArgsState extends State<_PostContentScreenForArgs> {
   void dispose() {
     super.dispose();
     widget.args.post.removeListener(postUpdated);
+    for (int i = 0; i < widget.args.post.comments.length; i++) {
+      if (widget.args.post.comments[i].unreadComment) {
+        widget.args.post.comments[i].unreadComment = false;
+      }
+    }
     var authorID = widget.args.post.summ.authorID;
     widget.client.getExistingChat(authorID)?.removeListener(authorUpdated);
   }

--- a/bruig/flutterui/bruig/lib/screens/overview.dart
+++ b/bruig/flutterui/bruig/lib/screens/overview.dart
@@ -5,6 +5,7 @@ import 'package:bruig/components/route_error.dart';
 import 'package:bruig/components/sidebar.dart';
 import 'package:bruig/models/client.dart';
 import 'package:bruig/models/downloads.dart';
+import 'package:bruig/models/feed.dart';
 import 'package:bruig/models/menus.dart';
 import 'package:bruig/models/notifications.dart';
 import 'package:bruig/screens/feed.dart';
@@ -68,8 +69,9 @@ class OverviewScreen extends StatefulWidget {
   final DownloadsModel down;
   final String initialRoute;
   final MainMenuModel mainMenu;
-  const OverviewScreen(
-      this.down, this.client, this.ntfns, this.initialRoute, this.mainMenu,
+  final FeedModel feed;
+  const OverviewScreen(this.down, this.client, this.ntfns, this.initialRoute,
+      this.mainMenu, this.feed,
       {Key? key})
       : super(key: key);
 
@@ -219,7 +221,8 @@ class _OverviewScreenState extends State<OverviewScreen> {
                   ])),
         ),
         body: Row(children: [
-          Sidebar(widget.client, widget.mainMenu, widget.ntfns, navKey),
+          Sidebar(widget.client, widget.mainMenu, widget.ntfns, navKey,
+              widget.feed),
           Expanded(
             child: Navigator(
               key: navKey,


### PR DESCRIPTION
This PR adds notifications for new posts and new comments to existing posts.  We will still need some further UX/UI improvement instead of simply adding "New Post/Comment" to the post listing on the News Feed screen.

New comments are currently bolded until the user clicks away from the post.