### PR TITLE
bruig: improve markdown image builder

### DIFF
--- a/bruig/flutterui/bruig/lib/components/image_dialog.dart
+++ b/bruig/flutterui/bruig/lib/components/image_dialog.dart
@@ -8,12 +8,13 @@ class ImageDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Dialog(
-      child: Image.memory(
-        imgContent,
-        width: 1000,
-        height: 1000,
-        fit: BoxFit.cover,
-        filterQuality: FilterQuality.high,
+      child: Container(
+        constraints: const BoxConstraints(maxHeight: 1000, maxWidth: 1000),
+        decoration: BoxDecoration(
+          image: DecorationImage(
+            image: MemoryImage(imgContent),
+          ),
+        ),
       ),
     );
   }

--- a/bruig/flutterui/bruig/lib/components/image_dialog.dart
+++ b/bruig/flutterui/bruig/lib/components/image_dialog.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'dart:typed_data';
+
+class ImageDialog extends StatelessWidget {
+  final Uint8List imgContent;
+  const ImageDialog(this.imgContent, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      child: Image.memory(
+        imgContent,
+        width: 1000,
+        height: 1000,
+        fit: BoxFit.cover,
+        filterQuality: FilterQuality.high,
+      ),
+    );
+  }
+}

--- a/bruig/flutterui/bruig/lib/components/md_elements.dart
+++ b/bruig/flutterui/bruig/lib/components/md_elements.dart
@@ -427,14 +427,12 @@ class ImageMd extends StatelessWidget {
                 context: context, builder: (_) => ImageDialog(imgContent));
           },
           child: Container(
-            width: 300,
-            height: 300,
+            constraints: const BoxConstraints(maxHeight: 250, maxWidth: 250),
             margin: const EdgeInsets.symmetric(horizontal: 2, vertical: 2),
             decoration: BoxDecoration(
               borderRadius: const BorderRadius.all(Radius.circular(8.0)),
               image: DecorationImage(
                 image: MemoryImage(imgContent),
-                fit: BoxFit.cover,
               ),
             ),
           ),

--- a/bruig/flutterui/bruig/lib/components/md_elements.dart
+++ b/bruig/flutterui/bruig/lib/components/md_elements.dart
@@ -11,6 +11,7 @@ import 'package:markdown/markdown.dart' as md;
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:bruig/theme_manager.dart';
+import 'package:bruig/components/image_dialog.dart';
 
 class DownloadSource {
   final String uid;
@@ -410,6 +411,37 @@ class Downloadable extends StatelessWidget {
       );
 }
 
+class ImageMd extends StatelessWidget {
+  final String tip;
+  final Uint8List imgContent;
+  const ImageMd(this.tip, this.imgContent, {Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) => Tooltip(
+        message: tip,
+        child: InkWell(
+          borderRadius: const BorderRadius.all(Radius.circular(30)),
+          hoverColor: Theme.of(context).hoverColor,
+          onTap: () {
+            showDialog(
+                context: context, builder: (_) => ImageDialog(imgContent));
+          },
+          child: Container(
+            width: 300,
+            height: 300,
+            margin: const EdgeInsets.symmetric(horizontal: 2, vertical: 2),
+            decoration: BoxDecoration(
+              borderRadius: const BorderRadius.all(Radius.circular(8.0)),
+              image: DecorationImage(
+                image: MemoryImage(imgContent),
+                fit: BoxFit.cover,
+              ),
+            ),
+          ),
+        ),
+      );
+}
+
 class CodeblockMarkdownElementBuilder extends MarkdownElementBuilder {
   @override
   Widget visitText(md.Text text, TextStyle? preferredStyle) {
@@ -465,14 +497,16 @@ class ImageMarkdownElementBuilder extends MarkdownElementBuilder {
       tip += "Click to download file $download";
     }
 
-    Image img;
     try {
-      img = Image.memory(imgBytes);
+      return ImageMd(tip, imgBytes);
     } catch (exception) {
       print("Unable to decode image: $exception");
-      img = Image.asset("assets/images/invalidimg.png");
+      return Image.asset(
+        "assets/images/invalidimg.png",
+        width: 300,
+        height: 300,
+        fit: BoxFit.cover,
+      );
     }
-
-    return Downloadable(tip, download, img);
   }
 }


### PR DESCRIPTION
Add a ImageDialog widget to improve the UX of markdown images. Solves a bunch of issues with scroll and different image sizes.

## Chats:
![chat_img_2](https://github.com/companyzero/bisonrelay/assets/13955303/47f28fd7-795c-4cc8-81e0-251aa74ee4f0)

## Posts:
![post_img_2](https://github.com/companyzero/bisonrelay/assets/13955303/940a37bd-d154-4280-9a64-7973e25f4a14)

