### PR TITLE
bruig: sync flutter_markdown and scrollable_positioned_list

### DIFF
--- a/bruig/flutterui/bruig/lib/components/chat/messages.dart
+++ b/bruig/flutterui/bruig/lib/components/chat/messages.dart
@@ -168,14 +168,16 @@ class _MessagesState extends State<Messages> {
     var backgroundColor = theme.backgroundColor;
     return Scaffold(
       floatingActionButton: _getFAB(textColor, backgroundColor),
-      body: ScrollablePositionedList.builder(
-        itemCount: chat.msgs.length,
-        physics: const ClampingScrollPhysics(),
-        itemBuilder: (context, index) {
-          return Event(chat, chat.msgs[index], nick, client, _scrollToBottom);
-        },
-        itemScrollController: widget.itemScrollController,
-        itemPositionsListener: widget.itemPositionsListener,
+      body: SelectionArea(
+        child: ScrollablePositionedList.builder(
+          itemCount: chat.msgs.length,
+          physics: const ClampingScrollPhysics(),
+          itemBuilder: (context, index) {
+            return Event(chat, chat.msgs[index], nick, client, _scrollToBottom);
+          },
+          itemScrollController: widget.itemScrollController,
+          itemPositionsListener: widget.itemPositionsListener,
+        ),
       ),
     );
   }

--- a/bruig/flutterui/bruig/pubspec.lock
+++ b/bruig/flutterui/bruig/pubspec.lock
@@ -187,7 +187,7 @@ packages:
     description:
       path: "packages/flutter_markdown"
       ref: main
-      resolved-ref: ef6b5a380e0d6fa2705c1b19e5613c60db01bfd0
+      resolved-ref: b98386c14fef19537a8b45a232c6b04c8cf49acd
       url: "https://github.com/tiagoalvesdulce/packages"
     source: git
     version: "0.6.14+1"
@@ -531,12 +531,11 @@ packages:
   scrollable_positioned_list:
     dependency: "direct main"
     description:
-      path: "packages/scrollable_positioned_list"
-      ref: HEAD
-      resolved-ref: f4981ba61c491955cca7b73916aa05c9fbf2056f
-      url: "https://github.com/tiagoalvesdulce/flutter.widgets"
-    source: git
-    version: "0.3.5"
+      name: scrollable_positioned_list
+      sha256: "1b54d5f1329a1e263269abc9e2543d90806131aa14fe7c6062a8054d57249287"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.8"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/bruig/flutterui/bruig/pubspec.yaml
+++ b/bruig/flutterui/bruig/pubspec.yaml
@@ -49,10 +49,7 @@ dependencies:
   package_info_plus: ^3.0.3
   open_filex: ^4.3.2
   loading_animation_widget: ^1.2.0
-  scrollable_positioned_list:
-    git:
-      url: https://github.com/tiagoalvesdulce/flutter.widgets
-      path: packages/scrollable_positioned_list
+  scrollable_positioned_list: ^0.3.8
   flutter_markdown:
     git:
       url: https://github.com/tiagoalvesdulce/packages


### PR DESCRIPTION
With https://github.com/google/flutter.widgets/pull/469, the [last release](https://pub.dev/packages/scrollable_positioned_list) of `scrollable_positioned_list` allow us to use `SelectionArea` with `ScrollablePositionedList` so we don't need to use my fork anymore.

Also synced the `flutter_markdown` upstream.