### PR TITLE
bruig: Notification fixes for chats and new comments

### DIFF
--- a/bruig/flutterui/bruig/lib/models/client.dart
+++ b/bruig/flutterui/bruig/lib/models/client.dart
@@ -779,9 +779,11 @@ class ClientModel extends ChangeNotifier {
       if (evnt is PM) {
         if (!evnt.mine) {
           source = chat;
+          hasUnreadChats = true;
         }
       } else if (evnt is GCMsg) {
         source = await _newChat(evnt.senderUID, "", false, false);
+        hasUnreadChats = true;
       } else if (evnt is GCUserEvent) {
         source = await _newChat(evnt.uid, "", false, false);
       } else {

--- a/bruig/flutterui/bruig/lib/screens/feed/post_content.dart
+++ b/bruig/flutterui/bruig/lib/screens/feed/post_content.dart
@@ -464,13 +464,16 @@ class _PostContentScreenForArgsState extends State<_PostContentScreenForArgs> {
   void dispose() {
     super.dispose();
     widget.args.post.removeListener(postUpdated);
-    for (int i = 0; i < widget.args.post.comments.length; i++) {
-      if (widget.args.post.comments[i].unreadComment) {
-        widget.args.post.comments[i].unreadComment = false;
-      }
-    }
+    setChildCommentsRead(widget.args.post.comments);
     var authorID = widget.args.post.summ.authorID;
     widget.client.getExistingChat(authorID)?.removeListener(authorUpdated);
+  }
+
+  void setChildCommentsRead(List<FeedCommentModel> comments) {
+    for (int i = 0; i < comments.length; i++) {
+      comments[i].unreadComment = false;
+      setChildCommentsRead(comments[i].children);
+    }
   }
 
   Future<void> launchUrlAwait(url) async {


### PR DESCRIPTION
Properly removes new comments indicator when a post has been viewed.  Properly shows new chat indicator when any new message arrives.