### PR TITLE
clients: add ignore list to idle user autounsub

### DIFF
--- a/brclient/appstate.go
+++ b/brclient/appstate.go
@@ -3174,8 +3174,9 @@ func newAppState(sendMsg func(tea.Msg), lndLogLines *sloglinesbuffer.Buffer,
 		ResourcesProvider: resRouter,
 		NoLoadChatHistory: args.NoLoadChatHistory,
 
-		AutoHandshakeInterval:       args.AutoHandshakeInterval,
-		AutoRemoveIdleUsersInterval: args.AutoRemoveIdleUsersInterval,
+		AutoHandshakeInterval:         args.AutoHandshakeInterval,
+		AutoRemoveIdleUsersInterval:   args.AutoRemoveIdleUsersInterval,
+		AutoRemoveIdleUsersIgnoreList: args.AutoRemoveIdleUsersIgnore,
 
 		CertConfirmer: func(ctx context.Context, cs *tls.ConnectionState,
 			svrID *zkidentity.PublicIdentity) error {

--- a/brclient/brclient.conf.go
+++ b/brclient/brclient.conf.go
@@ -66,6 +66,13 @@ root = {{ .Root }}
 # Set to zero to disable idle user removal.
 # autoremoveidleusersinterval = 60d
 
+# Comma-separated list of users to NOT auto-unsubscribe or remove from GCs
+# during the idle check. This may be either the nick or UID of the user. By
+# default, some well-known bots are included in this list:
+# 86abd31f2141b274196d481edd061a00ab7a56b61a31656775c8a590d612b966 - Oprah
+# ad716557157c1f191d8b5f8c6757ea41af49de27dc619fc87f337ca85be325ee - GC bot
+# autoremoveignorelist =
+
 # logging and debug
 [log]
 

--- a/bruig/flutterui/bruig/lib/main.dart
+++ b/bruig/flutterui/bruig/lib/main.dart
@@ -167,7 +167,8 @@ class _AppState extends State<App> with WindowListener {
           cfg.circuitLimit,
           cfg.noLoadChatHistory,
           cfg.autoHandshakeInterval,
-          cfg.autoRemoveIdleUsersInterval);
+          cfg.autoRemoveIdleUsersInterval,
+          cfg.autoRemoveIgnoreList);
       await Golib.initClient(initArgs);
 
       navkey.currentState!.pushReplacementNamed(OverviewScreen.routeName);

--- a/bruig/flutterui/plugin/lib/definitions.dart
+++ b/bruig/flutterui/plugin/lib/definitions.dart
@@ -59,6 +59,8 @@ class InitClient {
   final int autoHandshakeInterval;
   @JsonKey(name: 'auto_remove_idle_users_interval')
   final int autoRemoveIdleUsersInterval;
+  @JsonKey(name: 'auto_remove_idle_users_ignore')
+  final List<String> autoRemoveIdleUsersIgnore;
 
   InitClient(
       this.dbRoot,
@@ -82,7 +84,8 @@ class InitClient {
       this.circuitLimit,
       this.noLoadChatHistory,
       this.autoHandshakeInterval,
-      this.autoRemoveIdleUsersInterval);
+      this.autoRemoveIdleUsersInterval,
+      this.autoRemoveIdleUsersIgnore);
 
   Map<String, dynamic> toJson() => _$InitClientToJson(this);
 }

--- a/bruig/flutterui/plugin/lib/definitions.g.dart
+++ b/bruig/flutterui/plugin/lib/definitions.g.dart
@@ -29,6 +29,9 @@ InitClient _$InitClientFromJson(Map<String, dynamic> json) => InitClient(
       json['no_load_chat_history'] as bool,
       json['auto_handshake_interval'] as int,
       json['auto_remove_idle_users_interval'] as int,
+      (json['auto_remove_idle_users_ignore'] as List<dynamic>)
+          .map((e) => e as String)
+          .toList(),
     );
 
 Map<String, dynamic> _$InitClientToJson(InitClient instance) =>
@@ -55,6 +58,7 @@ Map<String, dynamic> _$InitClientToJson(InitClient instance) =>
       'no_load_chat_history': instance.noLoadChatHistory,
       'auto_handshake_interval': instance.autoHandshakeInterval,
       'auto_remove_idle_users_interval': instance.autoRemoveIdleUsersInterval,
+      'auto_remove_idle_users_ignore': instance.autoRemoveIdleUsersIgnore,
     };
 
 IDInit _$IDInitFromJson(Map<String, dynamic> json) => IDInit(

--- a/bruig/golib/command_handlers.go
+++ b/bruig/golib/command_handlers.go
@@ -385,8 +385,9 @@ func handleInitClient(handle uint32, args initClient) error {
 		ResourcesProvider: resRouter,
 		NoLoadChatHistory: args.NoLoadChatHistory,
 
-		AutoHandshakeInterval:       time.Duration(args.AutoHandshakeInterval) * time.Second,
-		AutoRemoveIdleUsersInterval: time.Duration(args.AutoRemoveIdleUsersInterval) * time.Second,
+		AutoHandshakeInterval:         time.Duration(args.AutoHandshakeInterval) * time.Second,
+		AutoRemoveIdleUsersInterval:   time.Duration(args.AutoRemoveIdleUsersInterval) * time.Second,
+		AutoRemoveIdleUsersIgnoreList: args.AutoRemoveIdleUsersIgnore,
 
 		CertConfirmer: func(ctx context.Context, cs *tls.ConnectionState,
 			svrID *zkidentity.PublicIdentity) error {

--- a/bruig/golib/definitions.go
+++ b/bruig/golib/definitions.go
@@ -37,8 +37,9 @@ type initClient struct {
 	TorIsolation  bool   `json:"torisolation"`
 	CircuitLimit  uint32 `json:"circuit_limit"`
 
-	AutoHandshakeInterval       int64 `json:"auto_handshake_interval"`
-	AutoRemoveIdleUsersInterval int64 `json:"auto_remove_idle_users_interval"`
+	AutoHandshakeInterval       int64    `json:"auto_handshake_interval"`
+	AutoRemoveIdleUsersInterval int64    `json:"auto_remove_idle_users_interval"`
+	AutoRemoveIdleUsersIgnore   []string `json:"auto_remove_idle_users_ignore"`
 }
 
 type iDInit struct {

--- a/client/client.go
+++ b/client/client.go
@@ -189,6 +189,12 @@ type Config struct {
 	// automatically removed from GCs the local client admins and will be
 	// automatically unsubscribed from posts.
 	AutoRemoveIdleUsersInterval time.Duration
+
+	// AutoRemoveIdleUsersIgnoreList is a list of users that should NOT be
+	// forcibly unsubscribed even if they are idle. The values may be an
+	// user's nick or the prefix of the string representatation of its nick
+	// (i.e. anything acceptable as returned by UserByNick()).
+	AutoRemoveIdleUsersIgnoreList []string
 }
 
 // logger creates a logger for the given subsystem in the configured backend.


### PR DESCRIPTION
This list includes well-known bots, to prevent them from being erroneously removed by default.
