### PR TITLE
bruig: Add android permissions to all to turn off optimize battery

### DIFF
--- a/bruig/flutterui/bruig/android/app/src/main/AndroidManifest.xml
+++ b/bruig/flutterui/bruig/android/app/src/main/AndroidManifest.xml
@@ -42,4 +42,5 @@
     </application>
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+    <uses-permission  android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
 </manifest>

--- a/bruig/flutterui/bruig/lib/main.dart
+++ b/bruig/flutterui/bruig/lib/main.dart
@@ -42,6 +42,7 @@ import 'package:golib_plugin/golib_plugin.dart';
 import 'package:provider/provider.dart';
 import 'package:window_manager/window_manager.dart';
 import './screens/app_start.dart';
+import 'package:optimize_battery/optimize_battery.dart';
 
 final Random random = Random();
 
@@ -56,6 +57,8 @@ void main(List<String> args) async {
   Golib.captureDcrlndLog();
   // DartVLC.initialize();
 
+  // Get user to stop optimizing battery usage
+  OptimizeBattery.stopOptimizingBatteryUsage();
   // The MockGolib was mostly useful during early stages of development.
   //UseMockGolib();
 

--- a/bruig/flutterui/bruig/pubspec.lock
+++ b/bruig/flutterui/bruig/pubspec.lock
@@ -392,6 +392,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.3.2"
+  optimize_battery:
+    dependency: "direct main"
+    description:
+      name: optimize_battery
+      sha256: "4f0f974addbe54d3a705c1da5bf3a4bdae39502b1b2d2a17f9da1e558a34a4f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.4"
   package_config:
     dependency: transitive
     description:

--- a/bruig/flutterui/bruig/pubspec.yaml
+++ b/bruig/flutterui/bruig/pubspec.yaml
@@ -59,6 +59,7 @@ dependencies:
       ref: main
       path: packages/flutter_markdown
   permission_handler: ^10.4.5
+  optimize_battery: ^0.0.4
 
 msix_config:
   display_name: Bison Relay GUI


### PR DESCRIPTION
From testing we've seen that a non-optimized (unrestricted) battery on Android is an improvement for receiving messages for longer periods.  This is especially important since we have no plans to implement Firebase Cloud Messaging (FCM) in BR.