### PR TITLE
bruig: Introduce light theme and consolidate various colors

### DIFF
--- a/bruig/flutterui/bruig/lib/components/buttons.dart
+++ b/bruig/flutterui/bruig/lib/components/buttons.dart
@@ -51,7 +51,7 @@ ButtonStyle emptyButtonStyle(ThemeData theme) {
 ButtonStyle readMoreButton(ThemeData theme) {
   return ElevatedButton.styleFrom(
     padding: const EdgeInsets.only(left: 10, top: 10, right: 10, bottom: 10),
-    foregroundColor: const Color(0xFF8E8D98),
+    foregroundColor: theme.dividerColor,
     //padding: EdgeInsets.symmetric(horizontal: 16),
     shape: RoundedRectangleBorder(
         borderRadius: const BorderRadius.all(Radius.circular(30)),

--- a/bruig/flutterui/bruig/lib/components/chat/messages.dart
+++ b/bruig/flutterui/bruig/lib/components/chat/messages.dart
@@ -170,7 +170,7 @@ class _MessagesState extends State<Messages> {
   Widget build(BuildContext context) {
     var theme = Theme.of(context);
     var textColor = theme.dividerColor;
-    var backgroundColor = theme.highlightColor;
+    var backgroundColor = theme.backgroundColor;
     return Scaffold(
         floatingActionButton: _getFAB(textColor, backgroundColor),
         body: PageStorage(

--- a/bruig/flutterui/bruig/lib/components/dcr_input.dart
+++ b/bruig/flutterui/bruig/lib/components/dcr_input.dart
@@ -15,7 +15,7 @@ Widget dcrInput(
         builder: (context, theme, _) => TextField(
             style: TextStyle(
                 fontSize: theme.getSmallFont(context),
-                color: Color(0xFF8E8D98)),
+                color: theme.getTheme().dividerColor),
             controller: controller,
             onChanged: (String v) {
               double amount = v != "" ? double.parse(v) : 0;
@@ -28,9 +28,9 @@ Widget dcrInput(
             decoration: InputDecoration(
               hintStyle: TextStyle(
                   fontSize: theme.getSmallFont(context),
-                  color: Color(0xFF8E8D98)),
+                  color: theme.getTheme().dividerColor),
               filled: true,
-              fillColor: const Color.fromARGB(255, 84, 84, 89),
+              fillColor: theme.getTheme().indicatorColor,
               hintText: "0.00",
               suffixText: "DCR",
             )));

--- a/bruig/flutterui/bruig/lib/components/empty_widget.dart
+++ b/bruig/flutterui/bruig/lib/components/empty_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 
 class Empty extends StatelessWidget {
   const Empty({Key? key}) : super(key: key);

--- a/bruig/flutterui/bruig/lib/components/inputs.dart
+++ b/bruig/flutterui/bruig/lib/components/inputs.dart
@@ -30,7 +30,7 @@ Widget intInput({
         builder: (context, theme, _) => TextField(
             style: TextStyle(
                 fontSize: theme.getSmallFont(context),
-                color: const Color(0xFF8E8D98)),
+                color: theme.getTheme().dividerColor),
             controller: controller,
             onChanged: (String v) {
               try {
@@ -45,7 +45,7 @@ Widget intInput({
             decoration: InputDecoration(
               hintStyle: TextStyle(
                   fontSize: theme.getSmallFont(context),
-                  color: const Color(0xFF8E8D98)),
+                  color: theme.getTheme().dividerColor),
               filled: true,
-              fillColor: const Color(0xFF121026),
+              fillColor: theme.getTheme().hoverColor,
             )));

--- a/bruig/flutterui/bruig/lib/components/snackbars.dart
+++ b/bruig/flutterui/bruig/lib/components/snackbars.dart
@@ -1,6 +1,7 @@
 import 'package:bruig/components/copyable.dart';
 import 'package:bruig/models/snackbar.dart';
 import 'package:flutter/material.dart';
+import 'package:bruig/theme_manager.dart';
 import 'package:provider/provider.dart';
 
 class SnackbarDisplayer extends StatefulWidget {
@@ -29,9 +30,10 @@ class _SnackbarDisplayerState extends State<SnackbarDisplayer> {
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(
             backgroundColor:
                 snackBarMsg.error ? Colors.red[300] : Colors.green[300],
-            content: Copyable(
-                snackBarMsg.msg, const TextStyle(color: Color(0xFFE4E3E6)),
-                showSnackbar: false)));
+            content: Consumer<ThemeNotifier>(
+                builder: (context, theme, _) => Copyable(snackBarMsg.msg,
+                    TextStyle(color: theme.getTheme().focusColor),
+                    showSnackbar: false))));
       }
     }
   }

--- a/bruig/flutterui/bruig/lib/models/menus.dart
+++ b/bruig/flutterui/bruig/lib/models/menus.dart
@@ -432,10 +432,11 @@ class SidebarSvgIcon extends StatelessWidget {
   Widget build(BuildContext context) {
     var theme = Theme.of(context);
     var unselectedTextColor = theme.iconTheme.color;
+    var dividerColor = theme.dividerColor;
     return SvgPicture.asset(
       assetName,
       colorFilter: ColorFilter.mode(
-          unselectedTextColor ?? const Color(0xFF8E8D98), BlendMode.srcIn),
+          unselectedTextColor ?? dividerColor, BlendMode.srcIn),
     );
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/about.dart
+++ b/bruig/flutterui/bruig/lib/screens/about.dart
@@ -1,5 +1,6 @@
 import 'package:bruig/components/buttons.dart';
 import 'package:bruig/components/empty_widget.dart';
+import 'package:bruig/screens/startupscreen.dart';
 import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:bruig/theme_manager.dart';
@@ -35,151 +36,110 @@ class _AboutScreenState extends State<AboutScreen> {
 
   @override
   Widget build(BuildContext context) {
-    var textColor = const Color(0xFFE4E3E6);
-    var backgroundColor = const Color(0xFF19172C);
-    var cardColor = const Color(0xFF05031A);
     bool isScreenSmall = MediaQuery.of(context).size.width <= 500;
 
-    return Consumer<ThemeNotifier>(
-        builder: (context, theme, child) => Scaffold(
-            body: Container(
-                color: backgroundColor,
-                child: Stack(children: [
-                  Container(
-                      decoration: const BoxDecoration(
-                          image: DecorationImage(
-                              fit: BoxFit.fill,
-                              image:
-                                  AssetImage("assets/images/loading-bg.png")))),
-                  Container(
-                      decoration: BoxDecoration(
-                          gradient: LinearGradient(
-                              begin: Alignment.bottomLeft,
-                              end: Alignment.topRight,
-                              colors: [
-                            cardColor,
-                            const Color(0xFF07051C),
-                            backgroundColor.withOpacity(0.34),
-                          ],
-                              stops: const [
-                            0,
-                            0.17,
-                            1
-                          ])),
-                      padding: const EdgeInsets.all(10),
-                      child: Column(
+    return StartupScreen(Consumer<ThemeNotifier>(
+        builder: (context, theme, child) => Column(
+              children: [
+                const SizedBox(height: 89),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Flexible(
+                        child: Align(
+                            child: SizedBox(
+                                width: 600,
+                                height: 300,
+                                child: Container(
+                                    padding: const EdgeInsets.all(10),
+                                    decoration: BoxDecoration(
+                                      borderRadius: const BorderRadius.all(
+                                          Radius.circular(30)),
+                                      border: Border.all(
+                                          color: theme.getTheme().focusColor),
+                                    ),
+                                    child: Flex(
+                                        direction: isScreenSmall
+                                            ? Axis.vertical
+                                            : Axis.horizontal,
+                                        children: [
+                                          Image.asset(
+                                            "assets/images/icon.png",
+                                            width: isScreenSmall ? 100 : 200,
+                                            height: isScreenSmall ? 100 : 200,
+                                          ),
+                                          Column(
+                                            mainAxisAlignment:
+                                                MainAxisAlignment.center,
+                                            children: [
+                                              Text(
+                                                  textAlign: TextAlign.left,
+                                                  "Bison Relay",
+                                                  style: TextStyle(
+                                                      color: theme
+                                                          .getTheme()
+                                                          .focusColor,
+                                                      fontSize: theme
+                                                          .getHugeFont(context),
+                                                      fontWeight:
+                                                          FontWeight.w200)),
+                                              const SizedBox(height: 10),
+                                              Text("Version $version",
+                                                  style: TextStyle(
+                                                      color: theme
+                                                          .getTheme()
+                                                          .focusColor,
+                                                      fontSize:
+                                                          theme.getLargeFont(
+                                                              context),
+                                                      fontWeight:
+                                                          FontWeight.w200)),
+                                              const SizedBox(height: 10),
+                                              RichText(
+                                                  text: TextSpan(children: [
+                                                WidgetSpan(
+                                                    alignment:
+                                                        PlaceholderAlignment
+                                                            .middle,
+                                                    child: Icon(
+                                                        color: theme
+                                                            .getTheme()
+                                                            .focusColor,
+                                                        size:
+                                                            theme.getMediumFont(
+                                                                context),
+                                                        Icons.copyright)),
+                                                TextSpan(
+                                                    text:
+                                                        "2022-2024 Company 0, LLC",
+                                                    style: TextStyle(
+                                                        color: theme
+                                                            .getTheme()
+                                                            .focusColor,
+                                                        fontSize:
+                                                            theme.getLargeFont(
+                                                                context),
+                                                        fontWeight:
+                                                            FontWeight.w200))
+                                              ]))
+                                            ],
+                                          )
+                                        ]))))),
+                  ],
+                ),
+                const SizedBox(height: 89),
+                widget.settings
+                    ? const Empty()
+                    : Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
                         children: [
-                          const SizedBox(height: 89),
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              Flexible(
-                                  child: Align(
-                                      child: SizedBox(
-                                          width: 600,
-                                          height: 300,
-                                          child: Container(
-                                              padding: const EdgeInsets.all(10),
-                                              decoration: BoxDecoration(
-                                                borderRadius:
-                                                    const BorderRadius.all(
-                                                        Radius.circular(30)),
-                                                border: Border.all(
-                                                    color: textColor),
-                                              ),
-                                              child: Flex(
-                                                  direction: isScreenSmall
-                                                      ? Axis.vertical
-                                                      : Axis.horizontal,
-                                                  children: [
-                                                    Image.asset(
-                                                      "assets/images/icon.png",
-                                                      width: isScreenSmall
-                                                          ? 100
-                                                          : 200,
-                                                      height: isScreenSmall
-                                                          ? 100
-                                                          : 200,
-                                                    ),
-                                                    Column(
-                                                      mainAxisAlignment:
-                                                          MainAxisAlignment
-                                                              .center,
-                                                      children: [
-                                                        Text(
-                                                            textAlign:
-                                                                TextAlign.left,
-                                                            "Bison Relay",
-                                                            style: TextStyle(
-                                                                color:
-                                                                    textColor,
-                                                                fontSize: theme
-                                                                    .getHugeFont(
-                                                                        context),
-                                                                fontWeight:
-                                                                    FontWeight
-                                                                        .w200)),
-                                                        const SizedBox(
-                                                            height: 10),
-                                                        Text("Version $version",
-                                                            style: TextStyle(
-                                                                color:
-                                                                    textColor,
-                                                                fontSize: theme
-                                                                    .getLargeFont(
-                                                                        context),
-                                                                fontWeight:
-                                                                    FontWeight
-                                                                        .w200)),
-                                                        const SizedBox(
-                                                            height: 10),
-                                                        RichText(
-                                                            text: TextSpan(
-                                                                children: [
-                                                              WidgetSpan(
-                                                                  alignment:
-                                                                      PlaceholderAlignment
-                                                                          .middle,
-                                                                  child: Icon(
-                                                                      color:
-                                                                          textColor,
-                                                                      size: theme
-                                                                          .getMediumFont(
-                                                                              context),
-                                                                      Icons
-                                                                          .copyright)),
-                                                              TextSpan(
-                                                                  text:
-                                                                      "2022-2024 Company 0, LLC",
-                                                                  style: TextStyle(
-                                                                      color:
-                                                                          textColor,
-                                                                      fontSize:
-                                                                          theme.getLargeFont(
-                                                                              context),
-                                                                      fontWeight:
-                                                                          FontWeight
-                                                                              .w200))
-                                                            ]))
-                                                      ],
-                                                    )
-                                                  ]))))),
-                            ],
-                          ),
-                          const SizedBox(height: 89),
-                          widget.settings
-                              ? const Empty()
-                              : Row(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  children: [
-                                      LoadingScreenButton(
-                                        empty: true,
-                                        onPressed: () => goBack(context),
-                                        text: "Go Back",
-                                      ),
-                                    ]),
-                        ],
-                      )),
-                ]))));
+                            LoadingScreenButton(
+                              empty: true,
+                              onPressed: () => goBack(context),
+                              text: "Go Back",
+                            ),
+                          ]),
+              ],
+            )));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/chats.dart
+++ b/bruig/flutterui/bruig/lib/screens/chats.dart
@@ -141,8 +141,8 @@ class _FundsNeededPage extends StatelessWidget {
   Widget build(BuildContext context) {
     var theme = Theme.of(context);
     var backgroundColor = theme.backgroundColor;
-    var textColor = const Color(0xFF8E8D98);
-    var secondaryTextColor = const Color(0xFFE4E3E6);
+    var textColor = theme.dividerColor;
+    var secondaryTextColor = theme.focusColor;
     bool isScreenSmall = MediaQuery.of(context).size.width <= 500;
 
     return Consumer<ThemeNotifier>(
@@ -200,7 +200,7 @@ class _LoadingAddressBookPage extends StatelessWidget {
   Widget build(BuildContext context) {
     var theme = Theme.of(context);
     var backgroundColor = theme.backgroundColor;
-    var textColor = const Color(0xFF8E8D98);
+    var textColor = theme.dividerColor;
 
     return Consumer<ThemeNotifier>(
         builder: (context, theme, child) => Container(
@@ -250,8 +250,8 @@ class _InviteNeededPageState extends State<_InviteNeededPage> {
   Widget build(BuildContext context) {
     var theme = Theme.of(context);
     var backgroundColor = theme.backgroundColor;
-    var textColor = const Color(0xFF8E8D98);
-    var secondaryTextColor = const Color(0xFFE4E3E6);
+    var textColor = theme.dividerColor;
+    var secondaryTextColor = theme.focusColor;
     bool isScreenSmall = MediaQuery.of(context).size.width <= 500;
     return Consumer<ThemeNotifier>(
         builder: (context, theme, child) => Container(

--- a/bruig/flutterui/bruig/lib/screens/contacts_msg_times.dart
+++ b/bruig/flutterui/bruig/lib/screens/contacts_msg_times.dart
@@ -28,7 +28,8 @@ class _UserLastMsgTime extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var textColor = const Color(0xFF8E8D98);
+    var theme = Theme.of(context);
+    var textColor = theme.dividerColor;
     return Container(
       margin: const EdgeInsets.only(top: 5),
       child: Row(children: [
@@ -94,7 +95,8 @@ class _ContactsLastMsgTimesScreenState
 
   @override
   Widget build(BuildContext context) {
-    var textColor = const Color(0xFF8E8D98);
+    var theme = Theme.of(context);
+    var textColor = theme.dividerColor;
     return Consumer<ThemeNotifier>(
         builder: (context, theme, child) => Scaffold(
               body: Center(

--- a/bruig/flutterui/bruig/lib/screens/fetch_invite.dart
+++ b/bruig/flutterui/bruig/lib/screens/fetch_invite.dart
@@ -1,5 +1,6 @@
 import 'package:bruig/components/empty_widget.dart';
 import 'package:bruig/components/snackbars.dart';
+import 'package:bruig/screens/startupscreen.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:golib_plugin/definitions.dart';
@@ -69,78 +70,46 @@ class _FetchInviteScreenState extends State<FetchInviteScreen> {
 
   @override
   Widget build(BuildContext context) {
-    var backgroundColor = const Color(0xFF19172C);
-    var cardColor = const Color(0xFF05031A);
-    var textColor = const Color(0xFF8E8D98);
-    return Consumer<ThemeNotifier>(
-        builder: (context, theme, child) => Scaffold(
-            body: Container(
-                color: backgroundColor,
-                child: Stack(children: [
-                  Container(
-                      decoration: const BoxDecoration(
-                          image: DecorationImage(
-                              fit: BoxFit.fill,
-                              image:
-                                  AssetImage("assets/images/loading-bg.png")))),
-                  Center(
-                      child: Container(
-                          decoration: BoxDecoration(
-                              gradient: LinearGradient(
-                                  begin: Alignment.bottomLeft,
-                                  end: Alignment.topRight,
-                                  colors: [
-                                cardColor,
-                                const Color(0xFF07051C),
-                                backgroundColor.withOpacity(0.34),
-                              ],
-                                  stops: const [
-                                0,
-                                0.17,
-                                1
-                              ])),
-                          padding: const EdgeInsets.all(10),
-                          child: Column(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                const Expanded(child: Empty()),
-                                Text("Fetch Invite",
-                                    style: TextStyle(
-                                        color: textColor,
-                                        fontSize: theme.getHugeFont(context),
-                                        fontWeight: FontWeight.w200)),
-                                const SizedBox(height: 20),
-                                SizedBox(
-                                    width: 400,
-                                    child: path != ""
-                                        ? Center(
-                                            child: Text(
-                                            "Save to: $path",
-                                            style: TextStyle(color: textColor),
-                                          ))
-                                        : ElevatedButton(
-                                            onPressed: selectPath,
-                                            child: const Text("Select Path"))),
-                                const SizedBox(height: 20),
-                                SizedBox(
-                                  width: 400,
-                                  child: TextField(
-                                    controller: keyCtrl,
-                                    decoration: const InputDecoration(
-                                        hintText: "Input key (bpik1...)"),
-                                  ),
-                                ),
-                                const SizedBox(height: 10),
-                                ElevatedButton(
-                                    onPressed: !loading && path != "" && hasKey
-                                        ? loadInvite
-                                        : null,
-                                    child: const Text("Fetch invite")),
-                                const Expanded(child: Empty()),
-                                ElevatedButton(
-                                    onPressed: () => Navigator.pop(context),
-                                    child: const Text("Cancel"))
-                              ])))
-                ]))));
+    return StartupScreen(Consumer<ThemeNotifier>(
+        builder: (context, theme, child) =>
+            Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+              const Expanded(child: Empty()),
+              Text("Fetch Invite",
+                  style: TextStyle(
+                      color: theme.getTheme().dividerColor,
+                      fontSize: theme.getHugeFont(context),
+                      fontWeight: FontWeight.w200)),
+              const SizedBox(height: 20),
+              SizedBox(
+                  width: 400,
+                  child: path != ""
+                      ? Center(
+                          child: Text(
+                          "Save to: $path",
+                          style:
+                              TextStyle(color: theme.getTheme().dividerColor),
+                        ))
+                      : ElevatedButton(
+                          onPressed: selectPath,
+                          child: const Text("Select Path"))),
+              const SizedBox(height: 20),
+              SizedBox(
+                width: 400,
+                child: TextField(
+                  controller: keyCtrl,
+                  decoration:
+                      const InputDecoration(hintText: "Input key (bpik1...)"),
+                ),
+              ),
+              const SizedBox(height: 10),
+              ElevatedButton(
+                  onPressed:
+                      !loading && path != "" && hasKey ? loadInvite : null,
+                  child: const Text("Fetch invite")),
+              const Expanded(child: Empty()),
+              ElevatedButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text("Cancel"))
+            ])));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/generate_invite.dart
+++ b/bruig/flutterui/bruig/lib/screens/generate_invite.dart
@@ -6,6 +6,7 @@ import 'package:bruig/components/copyable.dart';
 import 'package:bruig/components/dcr_input.dart';
 import 'package:bruig/components/empty_widget.dart';
 import 'package:bruig/components/snackbars.dart';
+import 'package:bruig/screens/startupscreen.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:golib_plugin/definitions.dart';
@@ -79,8 +80,9 @@ class _GenerateInviteScreenState extends State<GenerateInviteScreen> {
   }
 
   Widget buildSendFundsWidget(BuildContext context) {
-    var textColor = const Color(0xFF8E8D98);
-    var darkTextColor = const Color(0xFF5A5968);
+    var theme = Theme.of(context);
+    var textColor = theme.dividerColor;
+    var darkTextColor = theme.indicatorColor;
 
     if (!hasExtraAccounts) {
       return SizedBox(
@@ -147,7 +149,8 @@ class _GenerateInviteScreenState extends State<GenerateInviteScreen> {
   }
 
   List<Widget> buildGeneratedInvite(BuildContext context) {
-    var textColor = const Color(0xFF8E8D98);
+    var theme = Theme.of(context);
+    var textColor = theme.dividerColor;
     var ts = TextStyle(color: textColor);
     var gen = generated!;
     return [
@@ -169,7 +172,7 @@ class _GenerateInviteScreenState extends State<GenerateInviteScreen> {
 
   List<Widget> buildGeneratePanel(BuildContext context) {
     var theme = Theme.of(context);
-    var textColor = const Color(0xFF8E8D98);
+    var textColor = theme.dividerColor;
     return [
       SizedBox(
           width: 400,
@@ -215,51 +218,19 @@ class _GenerateInviteScreenState extends State<GenerateInviteScreen> {
 
   @override
   Widget build(BuildContext context) {
-    var backgroundColor = const Color(0xFF19172C);
-    var cardColor = const Color(0xFF05031A);
-    var textColor = const Color(0xFF8E8D98);
-    return Consumer<ThemeNotifier>(
-        builder: (context, theme, child) => Scaffold(
-            body: Container(
-                color: backgroundColor,
-                child: Stack(children: [
-                  Container(
-                      decoration: const BoxDecoration(
-                          image: DecorationImage(
-                              fit: BoxFit.fill,
-                              image:
-                                  AssetImage("assets/images/loading-bg.png")))),
-                  Center(
-                      child: Container(
-                          decoration: BoxDecoration(
-                              gradient: LinearGradient(
-                                  begin: Alignment.bottomLeft,
-                                  end: Alignment.topRight,
-                                  colors: [
-                                cardColor,
-                                const Color(0xFF07051C),
-                                backgroundColor.withOpacity(0.34),
-                              ],
-                                  stops: const [
-                                0,
-                                0.17,
-                                1
-                              ])),
-                          padding: const EdgeInsets.all(10),
-                          child: Column(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                const Expanded(child: Empty()),
-                                Text("Generate Invite",
-                                    style: TextStyle(
-                                        color: textColor,
-                                        fontSize: theme.getHugeFont(context),
-                                        fontWeight: FontWeight.w200)),
-                                const SizedBox(height: 20),
-                                ...(generated == null
-                                    ? buildGeneratePanel(context)
-                                    : buildGeneratedInvite(context)),
-                              ])))
-                ]))));
+    return StartupScreen(Consumer<ThemeNotifier>(
+        builder: (context, theme, child) =>
+            Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+              const Expanded(child: Empty()),
+              Text("Generate Invite",
+                  style: TextStyle(
+                      color: theme.getTheme().dividerColor,
+                      fontSize: theme.getHugeFont(context),
+                      fontWeight: FontWeight.w200)),
+              const SizedBox(height: 20),
+              ...(generated == null
+                  ? buildGeneratePanel(context)
+                  : buildGeneratedInvite(context)),
+            ])));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/init_local_id.dart
+++ b/bruig/flutterui/bruig/lib/screens/init_local_id.dart
@@ -1,5 +1,6 @@
 import 'package:bruig/components/snackbars.dart';
 import 'package:bruig/components/buttons.dart';
+import 'package:bruig/screens/startupscreen.dart';
 import 'package:flutter/material.dart';
 import 'package:golib_plugin/definitions.dart';
 import 'package:golib_plugin/golib_plugin.dart';
@@ -42,106 +43,68 @@ class InitLocalIDScreenState extends State<InitLocalIDScreen> {
 
   @override
   Widget build(BuildContext context) {
-    var backgroundColor = const Color(0xFF19172C);
-    var cardColor = const Color(0xFF05031A);
-    var textColor = const Color(0xFF8E8D98);
-    var secondaryTextColor = const Color(0xFFE4E3E6);
-
-    return Consumer<ThemeNotifier>(
-        builder: (context, theme, child) => Scaffold(
-            body: Center(
-                child: Container(
-                    color: backgroundColor,
-                    child: Stack(children: [
-                      Container(
-                          decoration: const BoxDecoration(
-                              image: DecorationImage(
-                                  fit: BoxFit.fill,
-                                  image: AssetImage(
-                                      "assets/images/loading-bg.png")))),
-                      Container(
-                        decoration: BoxDecoration(
-                            gradient: LinearGradient(
-                                begin: Alignment.bottomLeft,
-                                end: Alignment.topRight,
-                                colors: [
-                              cardColor,
-                              const Color(0xFF07051C),
-                              backgroundColor.withOpacity(0.34),
-                            ],
-                                stops: const [
-                              0,
-                              0.17,
-                              1
-                            ])),
-                        padding: const EdgeInsets.all(10),
-                        child: Column(children: [
-                          const SizedBox(height: 89),
-                          Text("Setting up Bison Relay",
-                              style: TextStyle(
-                                  color: textColor,
-                                  fontSize: theme.getHugeFont(context),
-                                  fontWeight: FontWeight.w200)),
-                          const SizedBox(height: 20),
-                          Text("Choose Username/Nick",
-                              style: TextStyle(
-                                  color: secondaryTextColor,
-                                  fontSize: theme.getLargeFont(context),
-                                  fontWeight: FontWeight.w300)),
-                          const SizedBox(height: 34),
-                          Column(children: [
-                            Form(
-                                key: _formKey,
-                                child: Column(children: [
-                                  Wrap(
-                                    runSpacing: 10,
-                                    children: <Widget>[
-                                      TextFormField(
-                                        decoration: const InputDecoration(
-                                            icon: Icon(Icons.person),
-                                            labelText: 'User Name',
-                                            hintText:
-                                                'Full name of the user (ex."John Doe")'),
-                                        onSaved: (String? v) => name = v!,
-                                        validator: (String? value) {
-                                          if (value != null &&
-                                              value.trim().isEmpty) {
-                                            return 'Cannot be blank';
-                                          }
-                                          return null;
-                                        },
-                                      ),
-                                      TextFormField(
-                                        decoration: const InputDecoration(
-                                            icon: Icon(Icons.person_outline),
-                                            labelText: 'Nick',
-                                            hintText: 'Short alias (ex."jd")'),
-                                        onSaved: (String? v) => nick = v!,
-                                        validator: (String? value) {
-                                          if (value != null &&
-                                              value.trim().isEmpty) {
-                                            return 'Cannot be blank';
-                                          }
-                                          if (value!
-                                              .contains(RegExp(r"[\W]"))) {
-                                            return 'Must be a single word without special chars';
-                                          }
-                                          return null;
-                                        },
-                                      ),
-                                      Container(height: 20),
-                                      Center(
-                                          child: LoadingScreenButton(
-                                        onPressed:
-                                            !connecting ? connectPressed : null,
-                                        text: "Confirm",
-                                      ))
-                                    ],
-                                  )
-                                ]))
-                          ]),
-                        ]),
-                      )
-                    ])))));
+    return StartupScreen(Consumer<ThemeNotifier>(
+      builder: (context, theme, child) => Column(children: [
+        const SizedBox(height: 89),
+        Text("Setting up Bison Relay",
+            style: TextStyle(
+                color: theme.getTheme().dividerColor,
+                fontSize: theme.getHugeFont(context),
+                fontWeight: FontWeight.w200)),
+        const SizedBox(height: 20),
+        Text("Choose Username/Nick",
+            style: TextStyle(
+                color: theme.getTheme().focusColor,
+                fontSize: theme.getLargeFont(context),
+                fontWeight: FontWeight.w300)),
+        const SizedBox(height: 34),
+        Column(children: [
+          Form(
+              key: _formKey,
+              child: Column(children: [
+                Wrap(
+                  runSpacing: 10,
+                  children: <Widget>[
+                    TextFormField(
+                      decoration: const InputDecoration(
+                          icon: Icon(Icons.person),
+                          labelText: 'User Name',
+                          hintText: 'Full name of the user (ex."John Doe")'),
+                      onSaved: (String? v) => name = v!,
+                      validator: (String? value) {
+                        if (value != null && value.trim().isEmpty) {
+                          return 'Cannot be blank';
+                        }
+                        return null;
+                      },
+                    ),
+                    TextFormField(
+                      decoration: const InputDecoration(
+                          icon: Icon(Icons.person_outline),
+                          labelText: 'Nick',
+                          hintText: 'Short alias (ex."jd")'),
+                      onSaved: (String? v) => nick = v!,
+                      validator: (String? value) {
+                        if (value != null && value.trim().isEmpty) {
+                          return 'Cannot be blank';
+                        }
+                        if (value!.contains(RegExp(r"[\W]"))) {
+                          return 'Must be a single word without special chars';
+                        }
+                        return null;
+                      },
+                    ),
+                    Container(height: 20),
+                    Center(
+                        child: LoadingScreenButton(
+                      onPressed: !connecting ? connectPressed : null,
+                      text: "Confirm",
+                    ))
+                  ],
+                )
+              ]))
+        ]),
+      ]),
+    ));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/needs_funds.dart
+++ b/bruig/flutterui/bruig/lib/screens/needs_funds.dart
@@ -5,6 +5,7 @@ import 'package:bruig/components/buttons.dart';
 import 'package:bruig/components/empty_widget.dart';
 import 'package:bruig/components/snackbars.dart';
 import 'package:bruig/models/notifications.dart';
+import 'package:bruig/screens/startupscreen.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:golib_plugin/definitions.dart';
@@ -115,10 +116,9 @@ class _NeedsFundsScreenState extends State<NeedsFundsScreen> {
   }
 
   Widget buildFundsWidget(BuildContext context) {
-    var secondaryTextColor = const Color(0xFFE4E3E6);
     return Consumer<ThemeNotifier>(builder: (context, theme, child) {
       var ts = TextStyle(
-          color: secondaryTextColor,
+          color: theme.getTheme().focusColor,
           fontSize: theme.getMediumFont(context),
           fontWeight: FontWeight.w300);
 
@@ -151,55 +151,24 @@ to redeem it by clicking in the button.
 
   @override
   Widget build(BuildContext context) {
-    var backgroundColor = const Color(0xFF19172C);
-    var cardColor = const Color(0xFF05031A);
-    var textColor = const Color(0xFF8E8D98);
-    var secondaryTextColor = const Color(0xFFE4E3E6);
-    var darkTextColor = const Color(0xFF5A5968);
-
-    return Consumer<ThemeNotifier>(
-        builder: (context, theme, child) => Scaffold(
-            body: Container(
-                color: backgroundColor,
-                child: Stack(children: [
-                  Container(
-                      decoration: const BoxDecoration(
-                          image: DecorationImage(
-                              fit: BoxFit.fill,
-                              image:
-                                  AssetImage("assets/images/loading-bg.png")))),
-                  Container(
-                      decoration: BoxDecoration(
-                          gradient: LinearGradient(
-                              begin: Alignment.bottomLeft,
-                              end: Alignment.topRight,
-                              colors: [
-                            cardColor,
-                            const Color(0xFF07051C),
-                            backgroundColor.withOpacity(0.34),
-                          ],
-                              stops: const [
-                            0,
-                            0.17,
-                            1
-                          ])),
-                      padding: const EdgeInsets.all(10),
-                      child: Column(
-                        children: [
-                          const Expanded(child: Empty()),
-                          Text("Setting up Bison Relay",
-                              style: TextStyle(
-                                  color: textColor,
-                                  fontSize: theme.getHugeFont(context),
-                                  fontWeight: FontWeight.w200)),
-                          const SizedBox(height: 20),
-                          Text("Receive Wallet Funds",
-                              style: TextStyle(
-                                  color: secondaryTextColor,
-                                  fontSize: theme.getLargeFont(context),
-                                  fontWeight: FontWeight.w300)),
-                          const SizedBox(height: 20),
-                          Text('''
+    return StartupScreen(
+      Consumer<ThemeNotifier>(
+          builder: (context, theme, child) => Column(
+                children: [
+                  const Expanded(child: Empty()),
+                  Text("Setting up Bison Relay",
+                      style: TextStyle(
+                          color: theme.getTheme().dividerColor,
+                          fontSize: theme.getHugeFont(context),
+                          fontWeight: FontWeight.w200)),
+                  const SizedBox(height: 20),
+                  Text("Receive Wallet Funds",
+                      style: TextStyle(
+                          color: theme.getTheme().focusColor,
+                          fontSize: theme.getLargeFont(context),
+                          fontWeight: FontWeight.w300)),
+                  const SizedBox(height: 20),
+                  Text('''
 The wallet requires on-chain DCR funds to be able to open Lightning Network (LN) channels
 and perform payments to the server and other users of the Bison Relay network.
 
@@ -207,78 +176,78 @@ Send DCR funds to the following address to receive funds in your wallet. Note th
 wallet seed will be needed to recover these funds if the wallet data in this computer is
 corrupted or lost.
 ''',
-                              style: TextStyle(
-                                  color: secondaryTextColor,
-                                  fontSize: theme.getMediumFont(context),
-                                  fontWeight: FontWeight.w300)),
-                          buildFundsWidget(context),
-                          const SizedBox(height: 13),
-                          Container(
-                              margin: const EdgeInsets.all(10),
-                              color: Colors.white,
-                              child: QrImageView(
-                                data: addr,
-                                version: QrVersions.auto,
-                                size: 200.0,
-                              )),
-                          const SizedBox(height: 13),
-                          Container(
-                              color: cardColor,
-                              padding: const EdgeInsets.only(
-                                  left: 22, top: 18, right: 22, bottom: 18),
-                              child: Copyable(
-                                  addr,
-                                  TextStyle(
-                                      color: textColor,
-                                      fontSize: theme.getMediumFont(context)))),
-                          const SizedBox(height: 9),
-                          Container(
-                              padding: const EdgeInsets.only(
-                                  left: 324 + 22, right: 324 + 20),
-                              child: Row(children: [
-                                Text(
-                                    textAlign: TextAlign.left,
-                                    "Unconfirmed wallet balance:",
-                                    style: TextStyle(
-                                        color: darkTextColor,
-                                        fontSize: theme.getSmallFont(context),
-                                        fontWeight: FontWeight.w300)),
-                                Text(
-                                    textAlign: TextAlign.right,
-                                    formatDCR(atomsToDCR(unconfirmedBalance)),
-                                    style: TextStyle(
-                                        color: darkTextColor,
-                                        fontSize: theme.getSmallFont(context),
-                                        fontWeight: FontWeight.w300)),
-                              ])),
-                          const SizedBox(height: 3),
-                          Container(
-                              padding: const EdgeInsets.only(
-                                  left: 324 + 22, right: 324 + 20),
-                              child: Row(children: [
-                                Text(
-                                    textAlign: TextAlign.left,
-                                    "Confirmed wallet balance:",
-                                    style: TextStyle(
-                                        color: darkTextColor,
-                                        fontSize: theme.getSmallFont(context),
-                                        fontWeight: FontWeight.w300)),
-                                Text(
-                                    textAlign: TextAlign.right,
-                                    formatDCR(atomsToDCR(confirmedBalance)),
-                                    style: TextStyle(
-                                        color: darkTextColor,
-                                        fontSize: theme.getSmallFont(context),
-                                        fontWeight: FontWeight.w300))
-                              ])),
-                          const SizedBox(height: 20),
-                          LoadingScreenButton(
-                            onPressed: () => Navigator.of(context).pop(),
-                            text: "Finish",
-                          ),
-                          const Expanded(child: Empty()),
-                        ],
+                      style: TextStyle(
+                          color: theme.getTheme().focusColor,
+                          fontSize: theme.getMediumFont(context),
+                          fontWeight: FontWeight.w300)),
+                  buildFundsWidget(context),
+                  const SizedBox(height: 13),
+                  Container(
+                      margin: const EdgeInsets.all(10),
+                      color: Colors.white,
+                      child: QrImageView(
+                        data: addr,
+                        version: QrVersions.auto,
+                        size: 200.0,
                       )),
-                ]))));
+                  const SizedBox(height: 13),
+                  Container(
+                      color: theme.getTheme().cardColor,
+                      padding: const EdgeInsets.only(
+                          left: 22, top: 18, right: 22, bottom: 18),
+                      child: Copyable(
+                          addr,
+                          TextStyle(
+                              color: theme.getTheme().dividerColor,
+                              fontSize: theme.getMediumFont(context)))),
+                  const SizedBox(height: 9),
+                  Container(
+                      padding: const EdgeInsets.only(
+                          left: 324 + 22, right: 324 + 20),
+                      child: Row(children: [
+                        Text(
+                            textAlign: TextAlign.left,
+                            "Unconfirmed wallet balance:",
+                            style: TextStyle(
+                                color: theme.getTheme().indicatorColor,
+                                fontSize: theme.getSmallFont(context),
+                                fontWeight: FontWeight.w300)),
+                        Text(
+                            textAlign: TextAlign.right,
+                            formatDCR(atomsToDCR(unconfirmedBalance)),
+                            style: TextStyle(
+                                color: theme.getTheme().indicatorColor,
+                                fontSize: theme.getSmallFont(context),
+                                fontWeight: FontWeight.w300)),
+                      ])),
+                  const SizedBox(height: 3),
+                  Container(
+                      padding: const EdgeInsets.only(
+                          left: 324 + 22, right: 324 + 20),
+                      child: Row(children: [
+                        Text(
+                            textAlign: TextAlign.left,
+                            "Confirmed wallet balance:",
+                            style: TextStyle(
+                                color: theme.getTheme().indicatorColor,
+                                fontSize: theme.getSmallFont(context),
+                                fontWeight: FontWeight.w300)),
+                        Text(
+                            textAlign: TextAlign.right,
+                            formatDCR(atomsToDCR(confirmedBalance)),
+                            style: TextStyle(
+                                color: theme.getTheme().indicatorColor,
+                                fontSize: theme.getSmallFont(context),
+                                fontWeight: FontWeight.w300))
+                      ])),
+                  const SizedBox(height: 20),
+                  LoadingScreenButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    text: "Finish",
+                  ),
+                  const Expanded(child: Empty()),
+                ],
+              )),
+    );
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/needs_in_channel.dart
+++ b/bruig/flutterui/bruig/lib/screens/needs_in_channel.dart
@@ -6,6 +6,7 @@ import 'package:bruig/components/info_grid.dart';
 import 'package:bruig/components/snackbars.dart';
 import 'package:bruig/models/client.dart';
 import 'package:bruig/models/notifications.dart';
+import 'package:bruig/screens/startupscreen.dart';
 import 'package:flutter/material.dart';
 import 'package:golib_plugin/golib_plugin.dart';
 import 'package:golib_plugin/util.dart';
@@ -186,63 +187,31 @@ cNPr8Y+sSs2MHf6xMNBQzV4KuIlPIg==
 
   @override
   Widget build(BuildContext context) {
-    var backgroundColor = const Color(0xFF19172C);
-    var cardColor = const Color(0xFF05031A);
-    var textColor = const Color(0xFF8E8D98);
-    var secondaryTextColor = const Color(0xFFE4E3E6);
-    var darkTextColor = const Color(0xFF5A5968);
-
-    return Consumer<ThemeNotifier>(
-        builder: (context, theme, child) => Scaffold(
-              body: Container(
-                color: backgroundColor,
-                child: Stack(children: [
-                  Container(
-                      decoration: const BoxDecoration(
-                          image: DecorationImage(
-                              fit: BoxFit.fill,
-                              image:
-                                  AssetImage("assets/images/loading-bg.png")))),
-                  Container(
-                    decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                            begin: Alignment.bottomLeft,
-                            end: Alignment.topRight,
-                            colors: [
-                          cardColor,
-                          const Color(0xFF07051C),
-                          backgroundColor.withOpacity(0.34),
-                        ],
-                            stops: const [
-                          0,
-                          0.17,
-                          1
-                        ])),
-                    padding: const EdgeInsets.all(10),
-                    child: ListView(
-                      physics: const ClampingScrollPhysics(),
-                      children: [
-                        const SizedBox(height: 89),
-                        Center(
-                          child: Text("Setting up Bison Relay",
-                              style: TextStyle(
-                                  color: textColor,
-                                  fontSize: theme.getHugeFont(context),
-                                  fontWeight: FontWeight.w200)),
-                        ),
-                        const SizedBox(height: 20),
-                        Center(
-                          child: Text("Add Inbound Capacity",
-                              style: TextStyle(
-                                  color: secondaryTextColor,
-                                  fontSize: theme.getLargeFont(context),
-                                  fontWeight: FontWeight.w300)),
-                        ),
-                        const SizedBox(height: 34),
-                        Center(
-                            child: SizedBox(
-                          width: 650,
-                          child: Text('''
+    return StartupScreen(Consumer<ThemeNotifier>(
+      builder: (context, theme, child) => ListView(
+        physics: const ClampingScrollPhysics(),
+        children: [
+          const SizedBox(height: 89),
+          Center(
+            child: Text("Setting up Bison Relay",
+                style: TextStyle(
+                    color: theme.getTheme().dividerColor,
+                    fontSize: theme.getHugeFont(context),
+                    fontWeight: FontWeight.w200)),
+          ),
+          const SizedBox(height: 20),
+          Center(
+            child: Text("Add Inbound Capacity",
+                style: TextStyle(
+                    color: theme.getTheme().focusColor,
+                    fontSize: theme.getLargeFont(context),
+                    fontWeight: FontWeight.w300)),
+          ),
+          const SizedBox(height: 34),
+          Center(
+              child: SizedBox(
+            width: 650,
+            child: Text('''
 The wallet requires LN channels with inbound capacity to receive funds to be able to receive payments from other users.
 
 One way of opening a channel with inbound capacity is to pay for a node to open a channel back to your LN wallet. This is done through a "Liquidity Provider" service.
@@ -251,171 +220,152 @@ Note that having a channel with inbound capacity is not for sending or receiving
 
 After the channel is opened, it may take up to 6 confirmations for it to be broadcast through the network. Individual peers may take longer to detect and to consider the channel to send payments.
                 ''',
-                              style: TextStyle(
-                                  color: secondaryTextColor,
-                                  fontSize: theme.getMediumFont(context),
-                                  fontWeight: FontWeight.w300)),
-                        )),
-                        const SizedBox(height: 21),
-                        Container(
-                            margin: const EdgeInsets.only(
-                                left: 324 + 22, right: 324 + 20),
-                            child: Row(
-                                mainAxisAlignment: MainAxisAlignment.center,
-                                children: [
-                                  Text(
-                                      textAlign: TextAlign.left,
-                                      "Outbound Channel Capacity:",
-                                      style: TextStyle(
-                                          color: darkTextColor,
-                                          fontSize: theme.getSmallFont(context),
-                                          fontWeight: FontWeight.w300)),
-                                  Text(
-                                      textAlign: TextAlign.right,
-                                      formatDCR(atomsToDCR(maxOutAmount)),
-                                      style: TextStyle(
-                                          color: darkTextColor,
-                                          fontSize: theme.getSmallFont(context),
-                                          fontWeight: FontWeight.w300)),
-                                ])),
-                        const SizedBox(height: 3),
-                        Row(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              Text(
-                                  textAlign: TextAlign.left,
-                                  "Inbound Channel Capacity:",
-                                  style: TextStyle(
-                                      color: darkTextColor,
-                                      fontSize: theme.getSmallFont(context),
-                                      fontWeight: FontWeight.w300)),
-                              Text(
-                                  textAlign: TextAlign.right,
-                                  formatDCR(atomsToDCR(maxInAmount)),
-                                  style: TextStyle(
-                                      color: darkTextColor,
-                                      fontSize: theme.getSmallFont(context),
-                                      fontWeight: FontWeight.w300))
-                            ]),
-                        Row(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              Text(
-                                  textAlign: TextAlign.left,
-                                  "Pending Channels:",
-                                  style: TextStyle(
-                                      color: darkTextColor,
-                                      fontSize: theme.getSmallFont(context),
-                                      fontWeight: FontWeight.w300)),
-                              Text(
-                                  textAlign: TextAlign.right,
-                                  "$numPendingChannels",
-                                  style: TextStyle(
-                                      color: darkTextColor,
-                                      fontSize: theme.getSmallFont(context),
-                                      fontWeight: FontWeight.w300))
-                            ]),
-                        Row(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              Text(
-                                  textAlign: TextAlign.left,
-                                  "Active Channels:",
-                                  style: TextStyle(
-                                      color: darkTextColor,
-                                      fontSize: theme.getSmallFont(context),
-                                      fontWeight: FontWeight.w300)),
-                              Text(
-                                  textAlign: TextAlign.right,
-                                  "$numChannels",
-                                  style: TextStyle(
-                                      color: darkTextColor,
-                                      fontSize: theme.getSmallFont(context),
-                                      fontWeight: FontWeight.w300))
-                            ]),
-                        const SizedBox(height: 10),
-                        preventMsg == ""
-                            ? Center(
-                                child: LoadingScreenButton(
-                                  empty: true,
-                                  onPressed: showAdvanced
-                                      ? hideAdvancedArea
-                                      : showAdvancedArea,
-                                  text: showAdvanced
-                                      ? "Hide Advanced"
-                                      : "Show Advanced",
-                                ),
-                              )
-                            : Empty(),
-                        const SizedBox(height: 10),
-                        preventMsg == ""
-                            ? ListView(
-                                physics: const NeverScrollableScrollPhysics(),
-                                shrinkWrap: true,
-                                padding: const EdgeInsets.all(15.0),
-                                children: [
-                                    Text("Amount",
-                                        style: TextStyle(
-                                            color: darkTextColor,
-                                            fontSize:
-                                                theme.getSmallFont(context),
-                                            fontWeight: FontWeight.w300)),
-                                    SizedBox(
-                                      width: 150,
-                                      child: dcrInput(controller: amountCtrl),
-                                    ),
-                                    const SizedBox(height: 50),
-                                    LoadingScreenButton(
-                                      onPressed:
-                                          !loading ? requestRecvCapacity : null,
-                                      text: "Request Inbound Channel",
-                                    ),
-                                    if (showAdvanced) ...[
-                                      const SizedBox(height: 10),
-                                      Text("LP Server Address",
-                                          style: TextStyle(
-                                              color: darkTextColor,
-                                              fontSize:
-                                                  theme.getSmallFont(context),
-                                              fontWeight: FontWeight.w300)),
-                                      TextField(
-                                        controller: serverCtrl,
-                                        decoration: const InputDecoration(
-                                            hintText:
-                                                "https://lpd-server:port"),
-                                      ),
-                                      const SizedBox(height: 10),
-                                      Text("LP Server Cert",
-                                          style: TextStyle(
-                                              color: darkTextColor,
-                                              fontSize:
-                                                  theme.getSmallFont(context),
-                                              fontWeight: FontWeight.w300)),
-                                      TextField(
-                                        controller: certCtrl,
-                                        maxLines: null,
-                                        keyboardType: TextInputType.multiline,
-                                      )
-                                    ]
-                                  ])
-                            : Column(children: [
-                                const SizedBox(height: 30),
-                                Text(
-                                  preventMsg,
-                                  style: TextStyle(color: textColor),
-                                )
-                              ]),
-                        Center(
-                          child: LoadingScreenButton(
-                            onPressed: () => Navigator.of(context).pop(),
-                            text: "Skip",
-                          ),
-                        )
-                      ],
-                    ),
+                style: TextStyle(
+                    color: theme.getTheme().focusColor,
+                    fontSize: theme.getMediumFont(context),
+                    fontWeight: FontWeight.w300)),
+          )),
+          const SizedBox(height: 21),
+          Container(
+              margin: const EdgeInsets.only(left: 324 + 22, right: 324 + 20),
+              child:
+                  Row(mainAxisAlignment: MainAxisAlignment.center, children: [
+                Text(
+                    textAlign: TextAlign.left,
+                    "Outbound Channel Capacity:",
+                    style: TextStyle(
+                        color: theme.getTheme().indicatorColor,
+                        fontSize: theme.getSmallFont(context),
+                        fontWeight: FontWeight.w300)),
+                Text(
+                    textAlign: TextAlign.right,
+                    formatDCR(atomsToDCR(maxOutAmount)),
+                    style: TextStyle(
+                        color: theme.getTheme().indicatorColor,
+                        fontSize: theme.getSmallFont(context),
+                        fontWeight: FontWeight.w300)),
+              ])),
+          const SizedBox(height: 3),
+          Row(mainAxisAlignment: MainAxisAlignment.center, children: [
+            Text(
+                textAlign: TextAlign.left,
+                "Inbound Channel Capacity:",
+                style: TextStyle(
+                    color: theme.getTheme().indicatorColor,
+                    fontSize: theme.getSmallFont(context),
+                    fontWeight: FontWeight.w300)),
+            Text(
+                textAlign: TextAlign.right,
+                formatDCR(atomsToDCR(maxInAmount)),
+                style: TextStyle(
+                    color: theme.getTheme().indicatorColor,
+                    fontSize: theme.getSmallFont(context),
+                    fontWeight: FontWeight.w300))
+          ]),
+          Row(mainAxisAlignment: MainAxisAlignment.center, children: [
+            Text(
+                textAlign: TextAlign.left,
+                "Pending Channels:",
+                style: TextStyle(
+                    color: theme.getTheme().indicatorColor,
+                    fontSize: theme.getSmallFont(context),
+                    fontWeight: FontWeight.w300)),
+            Text(
+                textAlign: TextAlign.right,
+                "$numPendingChannels",
+                style: TextStyle(
+                    color: theme.getTheme().indicatorColor,
+                    fontSize: theme.getSmallFont(context),
+                    fontWeight: FontWeight.w300))
+          ]),
+          Row(mainAxisAlignment: MainAxisAlignment.center, children: [
+            Text(
+                textAlign: TextAlign.left,
+                "Active Channels:",
+                style: TextStyle(
+                    color: theme.getTheme().indicatorColor,
+                    fontSize: theme.getSmallFont(context),
+                    fontWeight: FontWeight.w300)),
+            Text(
+                textAlign: TextAlign.right,
+                "$numChannels",
+                style: TextStyle(
+                    color: theme.getTheme().indicatorColor,
+                    fontSize: theme.getSmallFont(context),
+                    fontWeight: FontWeight.w300))
+          ]),
+          const SizedBox(height: 10),
+          preventMsg == ""
+              ? Center(
+                  child: LoadingScreenButton(
+                    empty: true,
+                    onPressed:
+                        showAdvanced ? hideAdvancedArea : showAdvancedArea,
+                    text: showAdvanced ? "Hide Advanced" : "Show Advanced",
                   ),
+                )
+              : Empty(),
+          const SizedBox(height: 10),
+          preventMsg == ""
+              ? ListView(
+                  physics: const NeverScrollableScrollPhysics(),
+                  shrinkWrap: true,
+                  padding: const EdgeInsets.all(15.0),
+                  children: [
+                      Text("Amount",
+                          style: TextStyle(
+                              color: theme.getTheme().indicatorColor,
+                              fontSize: theme.getSmallFont(context),
+                              fontWeight: FontWeight.w300)),
+                      SizedBox(
+                        width: 150,
+                        child: dcrInput(controller: amountCtrl),
+                      ),
+                      const SizedBox(height: 50),
+                      LoadingScreenButton(
+                        onPressed: !loading ? requestRecvCapacity : null,
+                        text: "Request Inbound Channel",
+                      ),
+                      if (showAdvanced) ...[
+                        const SizedBox(height: 10),
+                        Text("LP Server Address",
+                            style: TextStyle(
+                                color: theme.getTheme().indicatorColor,
+                                fontSize: theme.getSmallFont(context),
+                                fontWeight: FontWeight.w300)),
+                        TextField(
+                          controller: serverCtrl,
+                          decoration: const InputDecoration(
+                              hintText: "https://lpd-server:port"),
+                        ),
+                        const SizedBox(height: 10),
+                        Text("LP Server Cert",
+                            style: TextStyle(
+                                color: theme.getTheme().indicatorColor,
+                                fontSize: theme.getSmallFont(context),
+                                fontWeight: FontWeight.w300)),
+                        TextField(
+                          controller: certCtrl,
+                          maxLines: null,
+                          keyboardType: TextInputType.multiline,
+                        )
+                      ]
+                    ])
+              : Column(children: [
+                  const SizedBox(height: 30),
+                  Text(
+                    preventMsg,
+                    style: TextStyle(color: theme.getTheme().dividerColor),
+                  )
                 ]),
-              ),
-            ));
+          Center(
+            child: LoadingScreenButton(
+              onPressed: () => Navigator.of(context).pop(),
+              text: "Skip",
+            ),
+          )
+        ],
+      ),
+    ));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/needs_out_channel.dart
+++ b/bruig/flutterui/bruig/lib/screens/needs_out_channel.dart
@@ -7,6 +7,7 @@ import 'package:bruig/components/info_grid.dart';
 import 'package:bruig/components/snackbars.dart';
 import 'package:bruig/models/client.dart';
 import 'package:bruig/models/notifications.dart';
+import 'package:bruig/screens/startupscreen.dart';
 import 'package:flutter/material.dart';
 import 'package:golib_plugin/golib_plugin.dart';
 import 'package:golib_plugin/util.dart';
@@ -178,231 +179,179 @@ open channels to other LN nodes.''';
 
   @override
   Widget build(BuildContext context) {
-    var backgroundColor = const Color(0xFF19172C);
-    var cardColor = const Color(0xFF05031A);
-    var textColor = const Color(0xFF8E8D98);
-    var secondaryTextColor = const Color(0xFFE4E3E6);
-    var darkTextColor = const Color(0xFF5A5968);
-
-    return Consumer<ThemeNotifier>(
-        builder: (context, theme, child) => Scaffold(
-              body: Container(
-                color: backgroundColor,
-                child: Stack(children: [
-                  Container(
-                      decoration: const BoxDecoration(
-                          image: DecorationImage(
-                              fit: BoxFit.fill,
-                              image:
-                                  AssetImage("assets/images/loading-bg.png")))),
-                  Container(
-                    decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                            begin: Alignment.bottomLeft,
-                            end: Alignment.topRight,
-                            colors: [
-                          cardColor,
-                          const Color(0xFF07051C),
-                          backgroundColor.withOpacity(0.34),
-                        ],
-                            stops: const [
-                          0,
-                          0.17,
-                          1
-                        ])),
-                    padding: const EdgeInsets.all(10),
-                    child: ListView(
-                      physics: const ClampingScrollPhysics(),
-                      children: [
-                        const SizedBox(height: 89),
-                        Center(
-                          child: Text("Setting up Bison Relay",
-                              style: TextStyle(
-                                  color: textColor,
-                                  fontSize: theme.getHugeFont(context),
-                                  fontWeight: FontWeight.w200)),
-                        ),
-                        const SizedBox(height: 20),
-                        Center(
-                          child: Text("Add Outbound Capacity",
-                              style: TextStyle(
-                                  color: secondaryTextColor,
-                                  fontSize: theme.getLargeFont(context),
-                                  fontWeight: FontWeight.w300)),
-                        ),
-                        const SizedBox(height: 34),
-                        Center(
-                          child: SizedBox(
-                              width: 650,
-                              child: Text(
-                                '''
+    return StartupScreen(Consumer<ThemeNotifier>(
+      builder: (context, theme, child) => ListView(
+        physics: const ClampingScrollPhysics(),
+        children: [
+          const SizedBox(height: 89),
+          Center(
+            child: Text("Setting up Bison Relay",
+                style: TextStyle(
+                    color: theme.getTheme().dividerColor,
+                    fontSize: theme.getHugeFont(context),
+                    fontWeight: FontWeight.w200)),
+          ),
+          const SizedBox(height: 20),
+          Center(
+            child: Text("Add Outbound Capacity",
+                style: TextStyle(
+                    color: theme.getTheme().focusColor,
+                    fontSize: theme.getLargeFont(context),
+                    fontWeight: FontWeight.w300)),
+          ),
+          const SizedBox(height: 34),
+          Center(
+            child: SizedBox(
+                width: 650,
+                child: Text(
+                  '''
 The wallet requires LN channels with outbound capacity to send funds ("bandwidth") in order to pay for messages to and from the server and to pay other users for their content.
 
 Open a channel to an existing LN node, by entering its details below.
 
 Note that Lightning Network channels require managing off-chain data, and as such the wallet seed is NOT sufficient to restore their state.
                       ''',
-                                style: TextStyle(
-                                    color: secondaryTextColor,
-                                    fontSize: theme.getMediumFont(context),
-                                    fontWeight: FontWeight.w300),
-                              )),
-                        ),
-                        const SizedBox(height: 21),
-                        Container(
-                            margin: const EdgeInsets.only(
-                                left: 324 + 22, right: 324 + 20),
-                            child: Row(
-                                mainAxisAlignment: MainAxisAlignment.center,
-                                children: [
-                                  Text(
-                                      textAlign: TextAlign.left,
-                                      "Wallet Balance:",
-                                      style: TextStyle(
-                                          color: darkTextColor,
-                                          fontSize: theme.getSmallFont(context),
-                                          fontWeight: FontWeight.w300)),
-                                  Text(
-                                      textAlign: TextAlign.right,
-                                      formatDCR(atomsToDCR(walletBalance)),
-                                      style: TextStyle(
-                                          color: darkTextColor,
-                                          fontSize: theme.getSmallFont(context),
-                                          fontWeight: FontWeight.w300)),
-                                ])),
-                        const SizedBox(height: 3),
-                        Row(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              Text(
-                                  textAlign: TextAlign.left,
-                                  "Outbound Channel Capacity:",
-                                  style: TextStyle(
-                                      color: darkTextColor,
-                                      fontSize: theme.getSmallFont(context),
-                                      fontWeight: FontWeight.w300)),
-                              Text(
-                                  textAlign: TextAlign.right,
-                                  formatDCR(atomsToDCR(maxOutAmount)),
-                                  style: TextStyle(
-                                      color: darkTextColor,
-                                      fontSize: theme.getSmallFont(context),
-                                      fontWeight: FontWeight.w300))
-                            ]),
-                        Row(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              Text(
-                                  textAlign: TextAlign.left,
-                                  "Pending Channels:",
-                                  style: TextStyle(
-                                      color: darkTextColor,
-                                      fontSize: theme.getSmallFont(context),
-                                      fontWeight: FontWeight.w300)),
-                              Text(
-                                  textAlign: TextAlign.right,
-                                  "$numPendingChannels",
-                                  style: TextStyle(
-                                      color: darkTextColor,
-                                      fontSize: theme.getSmallFont(context),
-                                      fontWeight: FontWeight.w300))
-                            ]),
-                        Row(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              Text(
-                                  textAlign: TextAlign.left,
-                                  "Active Channels:",
-                                  style: TextStyle(
-                                      color: darkTextColor,
-                                      fontSize: theme.getSmallFont(context),
-                                      fontWeight: FontWeight.w300)),
-                              Text(
-                                  textAlign: TextAlign.right,
-                                  "$numChannels",
-                                  style: TextStyle(
-                                      color: darkTextColor,
-                                      fontSize: theme.getSmallFont(context),
-                                      fontWeight: FontWeight.w300))
-                            ]),
-                        const SizedBox(height: 10),
-                        preventMsg == ""
-                            ? Center(
-                                child: LoadingScreenButton(
-                                  empty: true,
-                                  onPressed: showAdvanced
-                                      ? hideAdvancedArea
-                                      : showAdvancedArea,
-                                  text: showAdvanced
-                                      ? "Hide Advanced"
-                                      : "Show Advanced",
-                                ),
-                              )
-                            : const Empty(),
-                        const SizedBox(height: 10),
-                        preventMsg == ""
-                            ? ListView(
-                                physics: const NeverScrollableScrollPhysics(),
-                                shrinkWrap: true,
-                                padding: const EdgeInsets.all(15.0),
-                                children: <Widget>[
-                                    SimpleInfoGrid([
-                                      Tuple2(
-                                          Text("Amount",
-                                              style: TextStyle(
-                                                  color: darkTextColor,
-                                                  fontSize: theme
-                                                      .getSmallFont(context),
-                                                  fontWeight: FontWeight.w300)),
-                                          SizedBox(
-                                            width: 150,
-                                            child: dcrInput(
-                                                controller: amountCtrl),
-                                          )),
-                                      Tuple2(
-                                          const SizedBox(height: 50),
-                                          LoadingScreenButton(
-                                            onPressed:
-                                                !loading ? openChannel : null,
-                                            text: "Request Outbound Channel",
-                                          ))
-                                    ]),
-                                    showAdvanced
-                                        ? SimpleInfoGrid([
-                                            Tuple2(
-                                                Text("Peer ID and Address",
-                                                    style: TextStyle(
-                                                        color: darkTextColor,
-                                                        fontSize:
-                                                            theme.getSmallFont(
-                                                                context),
-                                                        fontWeight:
-                                                            FontWeight.w300)),
-                                                TextField(
-                                                  controller: peerCtrl,
-                                                  decoration: const InputDecoration(
-                                                      hintText:
-                                                          "node-pub-key@addr:port"),
-                                                )),
-                                          ])
-                                        : const Empty(),
-                                  ])
-                            : Column(children: [
-                                const SizedBox(height: 30),
-                                Text(preventMsg,
-                                    style: TextStyle(color: textColor))
-                              ]),
-                        Center(
-                          child: LoadingScreenButton(
-                            onPressed: () => Navigator.of(context).pop(),
-                            text: "Skip",
-                          ),
-                        )
-                      ],
-                    ),
+                  style: TextStyle(
+                      color: theme.getTheme().focusColor,
+                      fontSize: theme.getMediumFont(context),
+                      fontWeight: FontWeight.w300),
+                )),
+          ),
+          const SizedBox(height: 21),
+          Container(
+              margin: const EdgeInsets.only(left: 324 + 22, right: 324 + 20),
+              child:
+                  Row(mainAxisAlignment: MainAxisAlignment.center, children: [
+                Text(
+                    textAlign: TextAlign.left,
+                    "Wallet Balance:",
+                    style: TextStyle(
+                        color: theme.getTheme().indicatorColor,
+                        fontSize: theme.getSmallFont(context),
+                        fontWeight: FontWeight.w300)),
+                Text(
+                    textAlign: TextAlign.right,
+                    formatDCR(atomsToDCR(walletBalance)),
+                    style: TextStyle(
+                        color: theme.getTheme().indicatorColor,
+                        fontSize: theme.getSmallFont(context),
+                        fontWeight: FontWeight.w300)),
+              ])),
+          const SizedBox(height: 3),
+          Row(mainAxisAlignment: MainAxisAlignment.center, children: [
+            Text(
+                textAlign: TextAlign.left,
+                "Outbound Channel Capacity:",
+                style: TextStyle(
+                    color: theme.getTheme().indicatorColor,
+                    fontSize: theme.getSmallFont(context),
+                    fontWeight: FontWeight.w300)),
+            Text(
+                textAlign: TextAlign.right,
+                formatDCR(atomsToDCR(maxOutAmount)),
+                style: TextStyle(
+                    color: theme.getTheme().indicatorColor,
+                    fontSize: theme.getSmallFont(context),
+                    fontWeight: FontWeight.w300))
+          ]),
+          Row(mainAxisAlignment: MainAxisAlignment.center, children: [
+            Text(
+                textAlign: TextAlign.left,
+                "Pending Channels:",
+                style: TextStyle(
+                    color: theme.getTheme().indicatorColor,
+                    fontSize: theme.getSmallFont(context),
+                    fontWeight: FontWeight.w300)),
+            Text(
+                textAlign: TextAlign.right,
+                "$numPendingChannels",
+                style: TextStyle(
+                    color: theme.getTheme().indicatorColor,
+                    fontSize: theme.getSmallFont(context),
+                    fontWeight: FontWeight.w300))
+          ]),
+          Row(mainAxisAlignment: MainAxisAlignment.center, children: [
+            Text(
+                textAlign: TextAlign.left,
+                "Active Channels:",
+                style: TextStyle(
+                    color: theme.getTheme().indicatorColor,
+                    fontSize: theme.getSmallFont(context),
+                    fontWeight: FontWeight.w300)),
+            Text(
+                textAlign: TextAlign.right,
+                "$numChannels",
+                style: TextStyle(
+                    color: theme.getTheme().indicatorColor,
+                    fontSize: theme.getSmallFont(context),
+                    fontWeight: FontWeight.w300))
+          ]),
+          const SizedBox(height: 10),
+          preventMsg == ""
+              ? Center(
+                  child: LoadingScreenButton(
+                    empty: true,
+                    onPressed:
+                        showAdvanced ? hideAdvancedArea : showAdvancedArea,
+                    text: showAdvanced ? "Hide Advanced" : "Show Advanced",
                   ),
+                )
+              : const Empty(),
+          const SizedBox(height: 10),
+          preventMsg == ""
+              ? ListView(
+                  physics: const NeverScrollableScrollPhysics(),
+                  shrinkWrap: true,
+                  padding: const EdgeInsets.all(15.0),
+                  children: <Widget>[
+                      SimpleInfoGrid([
+                        Tuple2(
+                            Text("Amount",
+                                style: TextStyle(
+                                    color: theme.getTheme().indicatorColor,
+                                    fontSize: theme.getSmallFont(context),
+                                    fontWeight: FontWeight.w300)),
+                            SizedBox(
+                              width: 150,
+                              child: dcrInput(controller: amountCtrl),
+                            )),
+                        Tuple2(
+                            const SizedBox(height: 50),
+                            LoadingScreenButton(
+                              onPressed: !loading ? openChannel : null,
+                              text: "Request Outbound Channel",
+                            ))
+                      ]),
+                      showAdvanced
+                          ? SimpleInfoGrid([
+                              Tuple2(
+                                  Text("Peer ID and Address",
+                                      style: TextStyle(
+                                          color:
+                                              theme.getTheme().indicatorColor,
+                                          fontSize: theme.getSmallFont(context),
+                                          fontWeight: FontWeight.w300)),
+                                  TextField(
+                                    controller: peerCtrl,
+                                    decoration: const InputDecoration(
+                                        hintText: "node-pub-key@addr:port"),
+                                  )),
+                            ])
+                          : const Empty(),
+                    ])
+              : Column(children: [
+                  const SizedBox(height: 30),
+                  Text(preventMsg,
+                      style: TextStyle(color: theme.getTheme().dividerColor))
                 ]),
-              ),
-            ));
+          Center(
+            child: LoadingScreenButton(
+              onPressed: () => Navigator.of(context).pop(),
+              text: "Skip",
+            ),
+          )
+        ],
+      ),
+    ));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/newconfig/delete_old_wallet.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/delete_old_wallet.dart
@@ -39,10 +39,6 @@ class _DeleteOldWalletPageState extends State<DeleteOldWalletPage> {
 
   @override
   Widget build(BuildContext context) {
-    var backgroundColor = const Color(0xFF19172C);
-    var cardColor = const Color(0xFF05031A);
-    var textColor = const Color(0xFF8E8D98);
-
     void goToAbout() {
       Navigator.of(context).pushNamed("/about");
     }
@@ -62,7 +58,7 @@ class _DeleteOldWalletPageState extends State<DeleteOldWalletPage> {
               const SizedBox(height: 39),
               Text("Remove old wallet",
                   style: TextStyle(
-                      color: textColor,
+                      color: theme.getTheme().dividerColor,
                       fontSize: theme.getHugeFont(context),
                       fontWeight: FontWeight.w200)),
               const SizedBox(height: 20),
@@ -72,7 +68,7 @@ class _DeleteOldWalletPageState extends State<DeleteOldWalletPage> {
                     child: Text(_warnMsg,
                         textAlign: TextAlign.left,
                         style: TextStyle(
-                            color: textColor,
+                            color: theme.getTheme().dividerColor,
                             fontSize: theme.getMediumFont(context),
                             fontWeight: FontWeight.w300))),
                 Center(
@@ -80,10 +76,11 @@ class _DeleteOldWalletPageState extends State<DeleteOldWalletPage> {
                       width: 377,
                       child: CheckboxListTile(
                         title: Text("Wallet does not have any funds",
-                            style: TextStyle(color: textColor)),
-                        activeColor: textColor,
+                            style: TextStyle(
+                                color: theme.getTheme().dividerColor)),
+                        activeColor: theme.getTheme().dividerColor,
                         value: deleteAccepted,
-                        side: BorderSide(color: textColor),
+                        side: BorderSide(color: theme.getTheme().dividerColor),
                         onChanged: (val) {
                           setState(() {
                             deleteAccepted = val ?? false;

--- a/bruig/flutterui/bruig/lib/screens/newconfig/delete_old_wallet.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/delete_old_wallet.dart
@@ -1,6 +1,7 @@
 import 'package:bruig/components/buttons.dart';
 import 'package:bruig/components/snackbars.dart';
 import 'package:bruig/models/newconfig.dart';
+import 'package:bruig/screens/startupscreen.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:bruig/theme_manager.dart';
@@ -46,90 +47,65 @@ class _DeleteOldWalletPageState extends State<DeleteOldWalletPage> {
       Navigator.of(context).pushNamed("/about");
     }
 
-    return Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => Container(
-            color: backgroundColor,
-            child: Stack(children: [
-              Container(
-                  decoration: const BoxDecoration(
-                      image: DecorationImage(
-                          fit: BoxFit.fill,
-                          image: AssetImage("assets/images/loading-bg.png")))),
-              Container(
-                  decoration: BoxDecoration(
-                      gradient: LinearGradient(
-                          begin: Alignment.bottomLeft,
-                          end: Alignment.topRight,
-                          colors: [
-                        cardColor,
-                        const Color(0xFF07051C),
-                        backgroundColor.withOpacity(0.34),
-                      ],
-                          stops: const [
-                        0,
-                        0.17,
-                        1
-                      ])),
-                  padding: const EdgeInsets.all(10),
-                  child: Column(children: [
-                    Row(children: [
-                      IconButton(
-                          alignment: Alignment.topLeft,
-                          tooltip: "About Bison Relay",
-                          iconSize: 50,
-                          onPressed: goToAbout,
-                          icon: Image.asset(
-                            "assets/images/icon.png",
-                          )),
-                    ]),
-                    const SizedBox(height: 39),
-                    Text("Remove old wallet",
+    return StartupScreen(Consumer<ThemeNotifier>(
+        builder: (context, theme, _) => Column(children: [
+              Row(children: [
+                IconButton(
+                    alignment: Alignment.topLeft,
+                    tooltip: "About Bison Relay",
+                    iconSize: 50,
+                    onPressed: goToAbout,
+                    icon: Image.asset(
+                      "assets/images/icon.png",
+                    )),
+              ]),
+              const SizedBox(height: 39),
+              Text("Remove old wallet",
+                  style: TextStyle(
+                      color: textColor,
+                      fontSize: theme.getHugeFont(context),
+                      fontWeight: FontWeight.w200)),
+              const SizedBox(height: 20),
+              Column(children: [
+                SizedBox(
+                    width: 377,
+                    child: Text(_warnMsg,
+                        textAlign: TextAlign.left,
                         style: TextStyle(
                             color: textColor,
-                            fontSize: theme.getHugeFont(context),
-                            fontWeight: FontWeight.w200)),
-                    const SizedBox(height: 20),
-                    Column(children: [
-                      SizedBox(
-                          width: 377,
-                          child: Text(_warnMsg,
-                              textAlign: TextAlign.left,
-                              style: TextStyle(
-                                  color: textColor,
-                                  fontSize: theme.getMediumFont(context),
-                                  fontWeight: FontWeight.w300))),
-                      Center(
-                        child: SizedBox(
-                            width: 377,
-                            child: CheckboxListTile(
-                              title: Text("Wallet does not have any funds",
-                                  style: TextStyle(color: textColor)),
-                              activeColor: textColor,
-                              value: deleteAccepted,
-                              side: BorderSide(color: textColor),
-                              onChanged: (val) {
-                                setState(() {
-                                  deleteAccepted = val ?? false;
-                                });
-                              },
-                            )),
-                      ),
-                      const SizedBox(height: 34),
-                      Center(
-                          child: SizedBox(
-                              width: 278,
-                              child: Row(children: [
-                                const SizedBox(width: 35),
-                                LoadingScreenButton(
-                                  onPressed: deleteAccepted && !deleting
-                                      ? () => deleteWalletDir(context)
-                                      : null,
-                                  text: "Delete Wallet",
-                                ),
-                                const SizedBox(width: 10),
-                              ])))
-                    ]),
-                  ]))
+                            fontSize: theme.getMediumFont(context),
+                            fontWeight: FontWeight.w300))),
+                Center(
+                  child: SizedBox(
+                      width: 377,
+                      child: CheckboxListTile(
+                        title: Text("Wallet does not have any funds",
+                            style: TextStyle(color: textColor)),
+                        activeColor: textColor,
+                        value: deleteAccepted,
+                        side: BorderSide(color: textColor),
+                        onChanged: (val) {
+                          setState(() {
+                            deleteAccepted = val ?? false;
+                          });
+                        },
+                      )),
+                ),
+                const SizedBox(height: 34),
+                Center(
+                    child: SizedBox(
+                        width: 278,
+                        child: Row(children: [
+                          const SizedBox(width: 35),
+                          LoadingScreenButton(
+                            onPressed: deleteAccepted && !deleting
+                                ? () => deleteWalletDir(context)
+                                : null,
+                            text: "Delete Wallet",
+                          ),
+                          const SizedBox(width: 10),
+                        ])))
+              ]),
             ])));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/newconfig/initializing.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/initializing.dart
@@ -1,4 +1,5 @@
 import 'package:bruig/models/newconfig.dart';
+import 'package:bruig/screens/startupscreen.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:bruig/theme_manager.dart';
@@ -34,58 +35,29 @@ class _InitializingNewConfPageState extends State<InitializingNewConfPage> {
 
   @override
   Widget build(BuildContext context) {
-    var backgroundColor = const Color(0xFF19172C);
-    var cardColor = const Color(0xFF05031A);
-    var textColor = const Color(0xFF8E8D98);
-
     void goToAbout() {
       Navigator.of(context).pushNamed("/about");
     }
 
-    return Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => Container(
-            color: backgroundColor,
-            child: Stack(children: [
-              Container(
-                  decoration: const BoxDecoration(
-                      image: DecorationImage(
-                          fit: BoxFit.fill,
-                          image: AssetImage("assets/images/loading-bg.png")))),
-              Container(
-                  decoration: BoxDecoration(
-                      gradient: LinearGradient(
-                          begin: Alignment.bottomLeft,
-                          end: Alignment.topRight,
-                          colors: [
-                        cardColor,
-                        const Color(0xFF07051C),
-                        backgroundColor.withOpacity(0.34),
-                      ],
-                          stops: const [
-                        0,
-                        0.17,
-                        1
-                      ])),
-                  padding: const EdgeInsets.all(10),
-                  child: Column(children: [
-                    Row(children: [
-                      IconButton(
-                          alignment: Alignment.topLeft,
-                          tooltip: "About Bison Relay",
-                          iconSize: 50,
-                          onPressed: goToAbout,
-                          icon: Image.asset(
-                            "assets/images/icon.png",
-                          )),
-                    ]),
-                    const SizedBox(height: 39),
-                    Text("Setting up Bison Relay",
-                        style: TextStyle(
-                            color: textColor,
-                            fontSize: theme.getHugeFont(context),
-                            fontWeight: FontWeight.w200)),
-                    const SizedBox(height: 20),
-                  ]))
+    return StartupScreen(Consumer<ThemeNotifier>(
+        builder: (context, theme, _) => Column(children: [
+              Row(children: [
+                IconButton(
+                    alignment: Alignment.topLeft,
+                    tooltip: "About Bison Relay",
+                    iconSize: 50,
+                    onPressed: goToAbout,
+                    icon: Image.asset(
+                      "assets/images/icon.png",
+                    )),
+              ]),
+              const SizedBox(height: 39),
+              Text("Setting up Bison Relay",
+                  style: TextStyle(
+                      color: theme.getTheme().dividerColor,
+                      fontSize: theme.getHugeFont(context),
+                      fontWeight: FontWeight.w200)),
+              const SizedBox(height: 20),
             ])));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/newconfig/ln_choice.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/ln_choice.dart
@@ -27,11 +27,6 @@ class LNChoicePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var backgroundColor = const Color(0xFF19172C);
-    var cardColor = const Color(0xFF05031A);
-    var textColor = const Color(0xFF8E8D98);
-    var secondaryTextColor = const Color(0xFFE4E3E6);
-
     void goToAbout() {
       Navigator.of(context).pushNamed("/about");
     }
@@ -51,13 +46,13 @@ class LNChoicePage extends StatelessWidget {
               const SizedBox(height: 208),
               Text("Setting up Bison Relay",
                   style: TextStyle(
-                      color: textColor,
+                      color: theme.getTheme().dividerColor,
                       fontSize: theme.getHugeFont(context),
                       fontWeight: FontWeight.w200)),
               const SizedBox(height: 20),
               Text("Choose Network Mode",
                   style: TextStyle(
-                      color: secondaryTextColor,
+                      color: theme.getTheme().focusColor,
                       fontSize: theme.getLargeFont(context),
                       fontWeight: FontWeight.w300)),
               const SizedBox(height: 34),
@@ -75,7 +70,8 @@ class LNChoicePage extends StatelessWidget {
               Row(mainAxisAlignment: MainAxisAlignment.center, children: [
                 TextButton(
                   onPressed: () => goBack(context),
-                  child: Text("Go Back", style: TextStyle(color: textColor)),
+                  child: Text("Go Back",
+                      style: TextStyle(color: theme.getTheme().dividerColor)),
                 )
               ])
             ])));

--- a/bruig/flutterui/bruig/lib/screens/newconfig/ln_choice.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/ln_choice.dart
@@ -1,4 +1,5 @@
 import 'package:bruig/models/newconfig.dart';
+import 'package:bruig/screens/startupscreen.dart';
 import 'package:flutter/material.dart';
 import 'package:bruig/components/buttons.dart';
 import 'package:provider/provider.dart';
@@ -35,69 +36,42 @@ class LNChoicePage extends StatelessWidget {
       Navigator.of(context).pushNamed("/about");
     }
 
-    return Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => Container(
-            color: backgroundColor,
-            child: Stack(children: [
-              Container(
-                  decoration: const BoxDecoration(
-                      image: DecorationImage(
-                          fit: BoxFit.fill,
-                          image: AssetImage("assets/images/loading-bg.png")))),
-              Container(
-                  decoration: BoxDecoration(
-                      gradient: LinearGradient(
-                          begin: Alignment.bottomLeft,
-                          end: Alignment.topRight,
-                          colors: [
-                        cardColor,
-                        const Color(0xFF07051C),
-                        backgroundColor.withOpacity(0.34),
-                      ],
-                          stops: const [
-                        0,
-                        0.17,
-                        1
-                      ])),
-                  padding: const EdgeInsets.all(10),
-                  child: Column(children: [
-                    Row(children: [
-                      IconButton(
-                          alignment: Alignment.topLeft,
-                          tooltip: "About Bison Relay",
-                          iconSize: 50,
-                          onPressed: goToAbout,
-                          icon: Image.asset(
-                            "assets/images/icon.png",
-                          )),
-                    ]),
-                    const SizedBox(height: 208),
-                    Text("Setting up Bison Relay",
-                        style: TextStyle(
-                            color: textColor,
-                            fontSize: theme.getHugeFont(context),
-                            fontWeight: FontWeight.w200)),
-                    const SizedBox(height: 20),
-                    Text("Choose Network Mode",
-                        style: TextStyle(
-                            color: secondaryTextColor,
-                            fontSize: theme.getLargeFont(context),
-                            fontWeight: FontWeight.w300)),
-                    const SizedBox(height: 34),
-                    Row(mainAxisAlignment: MainAxisAlignment.center, children: [
-                      LoadingScreenButton(
-                          onPressed: () =>
-                              setChoice(context, LNNodeType.internal),
-                          text: "Internal",
-                          empty: true),
-                      const SizedBox(width: 13),
-                      LoadingScreenButton(
-                          onPressed: () =>
-                              setChoice(context, LNNodeType.external),
-                          text: "External",
-                          empty: true),
-                    ])
-                  ])),
+    return StartupScreen(Consumer<ThemeNotifier>(
+        builder: (context, theme, _) => Column(children: [
+              Row(children: [
+                IconButton(
+                    alignment: Alignment.topLeft,
+                    tooltip: "About Bison Relay",
+                    iconSize: 50,
+                    onPressed: goToAbout,
+                    icon: Image.asset(
+                      "assets/images/icon.png",
+                    )),
+              ]),
+              const SizedBox(height: 208),
+              Text("Setting up Bison Relay",
+                  style: TextStyle(
+                      color: textColor,
+                      fontSize: theme.getHugeFont(context),
+                      fontWeight: FontWeight.w200)),
+              const SizedBox(height: 20),
+              Text("Choose Network Mode",
+                  style: TextStyle(
+                      color: secondaryTextColor,
+                      fontSize: theme.getLargeFont(context),
+                      fontWeight: FontWeight.w300)),
+              const SizedBox(height: 34),
+              Row(mainAxisAlignment: MainAxisAlignment.center, children: [
+                LoadingScreenButton(
+                    onPressed: () => setChoice(context, LNNodeType.internal),
+                    text: "Internal",
+                    empty: true),
+                const SizedBox(width: 13),
+                LoadingScreenButton(
+                    onPressed: () => setChoice(context, LNNodeType.external),
+                    text: "External",
+                    empty: true),
+              ]),
               Row(mainAxisAlignment: MainAxisAlignment.center, children: [
                 TextButton(
                   onPressed: () => goBack(context),

--- a/bruig/flutterui/bruig/lib/screens/newconfig/ln_choice_external.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/ln_choice_external.dart
@@ -6,6 +6,7 @@ import 'package:bruig/models/newconfig.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:bruig/theme_manager.dart';
+import 'package:bruig/screens/startupscreen.dart';
 
 class LNExternalWalletPage extends StatefulWidget {
   final NewConfigModel newconf;
@@ -77,171 +78,141 @@ class _LNExternalWalletPageState extends State<LNExternalWalletPage> {
 
   @override
   Widget build(BuildContext context) {
-    var backgroundColor = const Color(0xFF19172C);
-    var cardColor = const Color(0xFF05031A);
-    var textColor = const Color(0xFF8E8D98);
-    var secondaryTextColor = const Color(0xFFE4E3E6);
-    var darkTextColor = const Color(0xFF5A5968);
-
     void goToAbout() {
       Navigator.of(context).pushNamed("/about");
     }
 
-    return Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => Container(
-            color: backgroundColor,
-            child: Stack(children: [
-              Container(
-                  decoration: const BoxDecoration(
-                      image: DecorationImage(
-                          fit: BoxFit.fill,
-                          image: AssetImage("assets/images/loading-bg.png")))),
-              Container(
-                  decoration: BoxDecoration(
-                      gradient: LinearGradient(
-                          begin: Alignment.bottomLeft,
-                          end: Alignment.topRight,
-                          colors: [
-                        cardColor,
-                        const Color(0xFF07051C),
-                        backgroundColor.withOpacity(0.34),
-                      ],
-                          stops: const [
-                        0,
-                        0.17,
-                        1
-                      ])),
-                  padding: const EdgeInsets.all(10),
-                  child: Column(children: [
-                    Row(children: [
-                      IconButton(
-                          alignment: Alignment.topLeft,
-                          tooltip: "About Bison Relay",
-                          iconSize: 50,
-                          onPressed: goToAbout,
-                          icon: Image.asset(
-                            "assets/images/icon.png",
-                          )),
-                    ]),
-                    const SizedBox(height: 39),
-                    Text("Setting up Bison Relay",
+    return StartupScreen(Consumer<ThemeNotifier>(
+        builder: (context, theme, _) => Column(children: [
+              Row(children: [
+                IconButton(
+                    alignment: Alignment.topLeft,
+                    tooltip: "About Bison Relay",
+                    iconSize: 50,
+                    onPressed: goToAbout,
+                    icon: Image.asset(
+                      "assets/images/icon.png",
+                    )),
+              ]),
+              const SizedBox(height: 39),
+              Text("Setting up Bison Relay",
+                  style: TextStyle(
+                      color: theme.getTheme().dividerColor,
+                      fontSize: theme.getHugeFont(context),
+                      fontWeight: FontWeight.w200)),
+              const SizedBox(height: 20),
+              Text("External dcrlnd Config",
+                  style: TextStyle(
+                      color: theme.getTheme().focusColor,
+                      fontSize: theme.getLargeFont(context),
+                      fontWeight: FontWeight.w300)),
+              const SizedBox(height: 34),
+              Column(children: [
+                SizedBox(
+                    width: 377,
+                    child: Text("RPC Host",
+                        textAlign: TextAlign.left,
                         style: TextStyle(
-                            color: textColor,
-                            fontSize: theme.getHugeFont(context),
-                            fontWeight: FontWeight.w200)),
-                    const SizedBox(height: 20),
-                    Text("External dcrlnd Config",
+                            color: theme.getTheme().indicatorColor,
+                            fontSize: theme.getSmallFont(context),
+                            fontWeight: FontWeight.w300))),
+                const SizedBox(height: 5),
+                Center(
+                    child: SizedBox(
+                        width: 377,
+                        child: TextField(
+                            cursorColor: theme.getTheme().focusColor,
+                            decoration: InputDecoration(
+                                border: InputBorder.none,
+                                hintText: "RPC Host",
+                                hintStyle: TextStyle(
+                                    fontSize: theme.getLargeFont(context),
+                                    color: theme.getTheme().dividerColor),
+                                filled: true,
+                                fillColor: theme.getTheme().cardColor),
+                            style: TextStyle(
+                                color: theme.getTheme().focusColor,
+                                fontSize: theme.getLargeFont(context)),
+                            controller: hostCtrl))),
+                const SizedBox(height: 13),
+                SizedBox(
+                    width: 377,
+                    child: Text("TLS Cert Path",
+                        textAlign: TextAlign.left,
                         style: TextStyle(
-                            color: secondaryTextColor,
-                            fontSize: theme.getLargeFont(context),
-                            fontWeight: FontWeight.w300)),
-                    const SizedBox(height: 34),
-                    Column(children: [
-                      SizedBox(
-                          width: 377,
-                          child: Text("RPC Host",
-                              textAlign: TextAlign.left,
-                              style: TextStyle(
-                                  color: darkTextColor,
-                                  fontSize: theme.getSmallFont(context),
-                                  fontWeight: FontWeight.w300))),
-                      const SizedBox(height: 5),
-                      Center(
-                          child: SizedBox(
-                              width: 377,
-                              child: TextField(
-                                  cursorColor: secondaryTextColor,
-                                  decoration: InputDecoration(
-                                      border: InputBorder.none,
-                                      hintText: "RPC Host",
-                                      hintStyle: TextStyle(
-                                          fontSize: theme.getLargeFont(context),
-                                          color: textColor),
-                                      filled: true,
-                                      fillColor: cardColor),
-                                  style: TextStyle(
-                                      color: secondaryTextColor,
-                                      fontSize: theme.getLargeFont(context)),
-                                  controller: hostCtrl))),
-                      const SizedBox(height: 13),
-                      SizedBox(
-                          width: 377,
-                          child: Text("TLS Cert Path",
-                              textAlign: TextAlign.left,
-                              style: TextStyle(
-                                  color: darkTextColor,
-                                  fontSize: theme.getSmallFont(context),
-                                  fontWeight: FontWeight.w300))),
-                      const SizedBox(height: 5),
-                      Center(
-                          child: SizedBox(
-                              width: 377,
-                              child: TextField(
-                                  cursorColor: secondaryTextColor,
-                                  decoration: InputDecoration(
-                                      border: InputBorder.none,
-                                      hintText: "TLS Cert Path",
-                                      hintStyle: TextStyle(
-                                          fontSize: theme.getLargeFont(context),
-                                          color: textColor),
-                                      filled: true,
-                                      fillColor: cardColor),
-                                  style: TextStyle(
-                                      color: secondaryTextColor,
-                                      fontSize: theme.getLargeFont(context)),
-                                  controller: tlsCtrl))),
-                      const SizedBox(height: 13),
-                      SizedBox(
-                          width: 377,
-                          child: Text("Macarooon Path",
-                              textAlign: TextAlign.left,
-                              style: TextStyle(
-                                  color: darkTextColor,
-                                  fontSize: theme.getSmallFont(context),
-                                  fontWeight: FontWeight.w300))),
-                      const SizedBox(height: 5),
-                      Center(
-                          child: SizedBox(
-                              width: 377,
-                              child: TextField(
-                                  cursorColor: secondaryTextColor,
-                                  decoration: InputDecoration(
-                                      border: InputBorder.none,
-                                      hintText: "Macaroon Path",
-                                      hintStyle: TextStyle(
-                                          fontSize: theme.getLargeFont(context),
-                                          color: textColor),
-                                      filled: true,
-                                      fillColor: cardColor),
-                                  style: TextStyle(
-                                      color: secondaryTextColor,
-                                      fontSize: theme.getLargeFont(context)),
-                                  controller: macaroonCtrl))),
-                      const SizedBox(height: 34),
-                      Center(
-                          child: SizedBox(
-                              width: 283,
-                              child: Row(children: [
-                                const SizedBox(width: 35),
-                                LoadingScreenButton(
-                                  onPressed: !loading ? done : null,
-                                  text: "Connect Wallet",
-                                ),
-                                const SizedBox(width: 10),
-                                loading
-                                    ? SizedBox(
-                                        height: 25,
-                                        width: 25,
-                                        child: CircularProgressIndicator(
-                                            value: null,
-                                            backgroundColor: backgroundColor,
-                                            color: textColor,
-                                            strokeWidth: 2),
-                                      )
-                                    : const SizedBox(width: 25),
-                              ])))
-                    ])
-                  ]))
+                            color: theme.getTheme().indicatorColor,
+                            fontSize: theme.getSmallFont(context),
+                            fontWeight: FontWeight.w300))),
+                const SizedBox(height: 5),
+                Center(
+                    child: SizedBox(
+                        width: 377,
+                        child: TextField(
+                            cursorColor: theme.getTheme().focusColor,
+                            decoration: InputDecoration(
+                                border: InputBorder.none,
+                                hintText: "TLS Cert Path",
+                                hintStyle: TextStyle(
+                                    fontSize: theme.getLargeFont(context),
+                                    color: theme.getTheme().dividerColor),
+                                filled: true,
+                                fillColor: theme.getTheme().cardColor),
+                            style: TextStyle(
+                                color: theme.getTheme().focusColor,
+                                fontSize: theme.getLargeFont(context)),
+                            controller: tlsCtrl))),
+                const SizedBox(height: 13),
+                SizedBox(
+                    width: 377,
+                    child: Text("Macarooon Path",
+                        textAlign: TextAlign.left,
+                        style: TextStyle(
+                            color: theme.getTheme().indicatorColor,
+                            fontSize: theme.getSmallFont(context),
+                            fontWeight: FontWeight.w300))),
+                const SizedBox(height: 5),
+                Center(
+                    child: SizedBox(
+                        width: 377,
+                        child: TextField(
+                            cursorColor: theme.getTheme().focusColor,
+                            decoration: InputDecoration(
+                                border: InputBorder.none,
+                                hintText: "Macaroon Path",
+                                hintStyle: TextStyle(
+                                    fontSize: theme.getLargeFont(context),
+                                    color: theme.getTheme().dividerColor),
+                                filled: true,
+                                fillColor: theme.getTheme().cardColor),
+                            style: TextStyle(
+                                color: theme.getTheme().focusColor,
+                                fontSize: theme.getLargeFont(context)),
+                            controller: macaroonCtrl))),
+                const SizedBox(height: 34),
+                Center(
+                    child: SizedBox(
+                        width: 283,
+                        child: Row(children: [
+                          const SizedBox(width: 35),
+                          LoadingScreenButton(
+                            onPressed: !loading ? done : null,
+                            text: "Connect Wallet",
+                          ),
+                          const SizedBox(width: 10),
+                          loading
+                              ? SizedBox(
+                                  height: 25,
+                                  width: 25,
+                                  child: CircularProgressIndicator(
+                                      value: null,
+                                      backgroundColor:
+                                          theme.getTheme().backgroundColor,
+                                      color: theme.getTheme().dividerColor,
+                                      strokeWidth: 2),
+                                )
+                              : const SizedBox(width: 25),
+                        ])))
+              ])
             ])));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/newconfig/ln_choice_internal.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/ln_choice_internal.dart
@@ -2,6 +2,7 @@ import 'package:bruig/components/empty_widget.dart';
 import 'package:bruig/components/snackbars.dart';
 import 'package:bruig/components/buttons.dart';
 import 'package:bruig/models/newconfig.dart';
+import 'package:bruig/screens/startupscreen.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:bruig/theme_manager.dart';
@@ -66,166 +67,138 @@ class _LNInternalWalletPageState extends State<LNInternalWalletPage> {
 
   @override
   Widget build(BuildContext context) {
-    var backgroundColor = const Color(0xFF19172C);
-    var cardColor = const Color(0xFF05031A);
-    var textColor = const Color(0xFF8E8D98);
-    var secondaryTextColor = const Color(0xFFE4E3E6);
-    var darkTextColor = const Color(0xFF5A5968);
-
     void goToAbout() {
       Navigator.of(context).pushNamed("/about");
     }
 
-    return Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => Container(
-            color: backgroundColor,
-            child: Stack(children: [
-              Container(
-                  decoration: const BoxDecoration(
-                      image: DecorationImage(
-                          fit: BoxFit.fill,
-                          image: AssetImage("assets/images/loading-bg.png")))),
-              Container(
-                  decoration: BoxDecoration(
-                      gradient: LinearGradient(
-                          begin: Alignment.bottomLeft,
-                          end: Alignment.topRight,
-                          colors: [
-                        cardColor,
-                        const Color(0xFF07051C),
-                        backgroundColor.withOpacity(0.34),
-                      ],
-                          stops: const [
-                        0,
-                        0.17,
-                        1
-                      ])),
-                  padding: const EdgeInsets.all(10),
-                  child: Column(children: [
-                    Row(children: [
-                      IconButton(
-                          alignment: Alignment.topLeft,
-                          tooltip: "About Bison Relay",
-                          iconSize: 50,
-                          onPressed: goToAbout,
-                          icon: Image.asset(
-                            "assets/images/icon.png",
-                          )),
-                    ]),
-                    const SizedBox(height: 39),
-                    Text("Setting up Bison Relay",
+    return StartupScreen(Consumer<ThemeNotifier>(
+        builder: (context, theme, _) => Column(children: [
+              Row(children: [
+                IconButton(
+                    alignment: Alignment.topLeft,
+                    tooltip: "About Bison Relay",
+                    iconSize: 50,
+                    onPressed: goToAbout,
+                    icon: Image.asset(
+                      "assets/images/icon.png",
+                    )),
+              ]),
+              const SizedBox(height: 39),
+              Text("Setting up Bison Relay",
+                  style: TextStyle(
+                      color: theme.getTheme().dividerColor,
+                      fontSize: theme.getHugeFont(context),
+                      fontWeight: FontWeight.w200)),
+              const SizedBox(height: 20),
+              Text(
+                  newconf.seedToRestore.isEmpty
+                      ? "Creating New Wallet"
+                      : "Restoring Wallet",
+                  style: TextStyle(
+                      color: theme.getTheme().focusColor,
+                      fontSize: theme.getLargeFont(context),
+                      fontWeight: FontWeight.w300)),
+              const SizedBox(height: 34),
+              Column(children: [
+                SizedBox(
+                    width: 377,
+                    child: Text("Wallet Password",
+                        textAlign: TextAlign.left,
                         style: TextStyle(
-                            color: textColor,
-                            fontSize: theme.getHugeFont(context),
-                            fontWeight: FontWeight.w200)),
-                    const SizedBox(height: 20),
-                    Text(
-                        newconf.seedToRestore.isEmpty
-                            ? "Creating New Wallet"
-                            : "Restoring Wallet",
+                            color: theme.getTheme().indicatorColor,
+                            fontSize: theme.getMediumFont(context),
+                            fontWeight: FontWeight.w300))),
+                Center(
+                    child: SizedBox(
+                        width: 377,
+                        child: TextField(
+                            cursorColor: theme.getTheme().focusColor,
+                            decoration: InputDecoration(
+                                border: InputBorder.none,
+                                hintText: "Password",
+                                hintStyle: TextStyle(
+                                    fontSize: theme.getLargeFont(context),
+                                    color: theme.getTheme().dividerColor),
+                                filled: true,
+                                fillColor: theme.getTheme().cardColor),
+                            style: TextStyle(
+                                color: theme.getTheme().focusColor,
+                                fontSize: theme.getLargeFont(context)),
+                            controller: passCtrl,
+                            obscureText: true))),
+                const SizedBox(height: 13),
+                SizedBox(
+                    width: 377,
+                    child: Text("Repeat Password",
+                        textAlign: TextAlign.left,
                         style: TextStyle(
-                            color: secondaryTextColor,
-                            fontSize: theme.getLargeFont(context),
-                            fontWeight: FontWeight.w300)),
-                    const SizedBox(height: 34),
-                    Column(children: [
-                      SizedBox(
-                          width: 377,
-                          child: Text("Wallet Password",
-                              textAlign: TextAlign.left,
-                              style: TextStyle(
-                                  color: darkTextColor,
-                                  fontSize: theme.getMediumFont(context),
-                                  fontWeight: FontWeight.w300))),
-                      Center(
-                          child: SizedBox(
-                              width: 377,
-                              child: TextField(
-                                  cursorColor: secondaryTextColor,
-                                  decoration: InputDecoration(
-                                      border: InputBorder.none,
-                                      hintText: "Password",
-                                      hintStyle: TextStyle(
-                                          fontSize: theme.getLargeFont(context),
-                                          color: textColor),
-                                      filled: true,
-                                      fillColor: cardColor),
-                                  style: TextStyle(
-                                      color: secondaryTextColor,
-                                      fontSize: theme.getLargeFont(context)),
-                                  controller: passCtrl,
-                                  obscureText: true))),
-                      const SizedBox(height: 13),
-                      SizedBox(
-                          width: 377,
-                          child: Text("Repeat Password",
-                              textAlign: TextAlign.left,
-                              style: TextStyle(
-                                  color: darkTextColor,
-                                  fontSize: theme.getMediumFont(context),
-                                  fontWeight: FontWeight.w300))),
-                      Center(
-                        child: SizedBox(
-                            width: 377,
-                            child: TextField(
-                                cursorColor: secondaryTextColor,
-                                decoration: InputDecoration(
-                                    border: InputBorder.none,
-                                    hintText: "Confirm",
-                                    hintStyle: TextStyle(
-                                        fontSize: theme.getLargeFont(context),
-                                        color: textColor),
-                                    filled: true,
-                                    fillColor: cardColor),
-                                //decoration: InputDecoration(),
-                                style: TextStyle(
-                                    color: secondaryTextColor,
-                                    fontSize: theme.getLargeFont(context)),
-                                controller: passRepeatCtrl,
-                                obscureText: true)),
-                      ),
-                      const SizedBox(height: 34),
-                      Center(
-                          child: SizedBox(
-                              width: 278,
-                              child: Row(children: [
-                                const SizedBox(width: 35),
-                                LoadingScreenButton(
-                                  onPressed: !loading ? createWallet : null,
-                                  text: "Create Wallet",
-                                ),
-                                const SizedBox(width: 10),
-                                loading
-                                    ? SizedBox(
-                                        height: 25,
-                                        width: 25,
-                                        child: CircularProgressIndicator(
-                                            value: null,
-                                            backgroundColor: backgroundColor,
-                                            color: textColor,
-                                            strokeWidth: 2),
-                                      )
-                                    : const SizedBox(width: 25),
-                              ]))),
-                    ]),
-                    const Expanded(child: Empty()),
-                    Row(mainAxisAlignment: MainAxisAlignment.center, children: [
-                      !newconf.advancedSetup
-                          ? TextButton(
-                              onPressed: startAdvancedSetup,
-                              child: Text("Advanced Setup",
-                                  style: TextStyle(color: textColor)),
-                            )
-                          : const Empty(),
-                      newconf.seedToRestore.isEmpty
-                          ? TextButton(
-                              onPressed: startSeedRestore,
-                              child: Text("Restore from Seed",
-                                  style: TextStyle(color: textColor)),
-                            )
-                          : const Empty(),
-                    ])
-                  ]))
+                            color: theme.getTheme().indicatorColor,
+                            fontSize: theme.getMediumFont(context),
+                            fontWeight: FontWeight.w300))),
+                Center(
+                  child: SizedBox(
+                      width: 377,
+                      child: TextField(
+                          cursorColor: theme.getTheme().focusColor,
+                          decoration: InputDecoration(
+                              border: InputBorder.none,
+                              hintText: "Confirm",
+                              hintStyle: TextStyle(
+                                  fontSize: theme.getLargeFont(context),
+                                  color: theme.getTheme().dividerColor),
+                              filled: true,
+                              fillColor: theme.getTheme().cardColor),
+                          //decoration: InputDecoration(),
+                          style: TextStyle(
+                              color: theme.getTheme().focusColor,
+                              fontSize: theme.getLargeFont(context)),
+                          controller: passRepeatCtrl,
+                          obscureText: true)),
+                ),
+                const SizedBox(height: 34),
+                Center(
+                    child: SizedBox(
+                        width: 278,
+                        child: Row(children: [
+                          const SizedBox(width: 35),
+                          LoadingScreenButton(
+                            onPressed: !loading ? createWallet : null,
+                            text: "Create Wallet",
+                          ),
+                          const SizedBox(width: 10),
+                          loading
+                              ? SizedBox(
+                                  height: 25,
+                                  width: 25,
+                                  child: CircularProgressIndicator(
+                                      value: null,
+                                      backgroundColor:
+                                          theme.getTheme().backgroundColor,
+                                      color: theme.getTheme().dividerColor,
+                                      strokeWidth: 2),
+                                )
+                              : const SizedBox(width: 25),
+                        ]))),
+              ]),
+              const Expanded(child: Empty()),
+              Row(mainAxisAlignment: MainAxisAlignment.center, children: [
+                !newconf.advancedSetup
+                    ? TextButton(
+                        onPressed: startAdvancedSetup,
+                        child: Text("Advanced Setup",
+                            style: TextStyle(
+                                color: theme.getTheme().dividerColor)),
+                      )
+                    : const Empty(),
+                newconf.seedToRestore.isEmpty
+                    ? TextButton(
+                        onPressed: startSeedRestore,
+                        child: Text("Restore from Seed",
+                            style: TextStyle(
+                                color: theme.getTheme().dividerColor)),
+                      )
+                    : const Empty(),
+              ])
             ])));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/newconfig/ln_wallet_seed.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/ln_wallet_seed.dart
@@ -1,5 +1,6 @@
 import 'package:bruig/components/empty_widget.dart';
 import 'package:bruig/models/newconfig.dart';
+import 'package:bruig/screens/startupscreen.dart';
 import 'package:flutter/material.dart';
 import 'package:bruig/components/buttons.dart';
 import 'package:flutter/services.dart';
@@ -26,86 +27,58 @@ class NewLNWalletSeedPage extends StatelessWidget {
     }
 
     var backgroundColor = const Color(0xFF19172C);
-    var cardColor = const Color(0xFF05031A);
-    var textColor = const Color(0xFF8E8D98);
-    var secondaryTextColor = const Color(0xFFE4E3E6);
     var seedWords = newconf.newWalletSeed.split(' ');
 
-    return Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => Container(
-            color: backgroundColor,
-            child: Stack(children: [
-              Container(
-                  decoration: const BoxDecoration(
-                      image: DecorationImage(
-                          fit: BoxFit.fill,
-                          image: AssetImage("assets/images/loading-bg.png")))),
-              Container(
-                decoration: BoxDecoration(
-                    gradient: LinearGradient(
-                        begin: Alignment.bottomLeft,
-                        end: Alignment.topRight,
-                        colors: [
-                      cardColor,
-                      const Color(0xFF07051C),
-                      backgroundColor.withOpacity(0.34),
-                    ],
-                        stops: const [
-                      0,
-                      0.17,
-                      1
-                    ])),
-                padding: const EdgeInsets.all(10),
-                child: Column(children: [
-                  Row(children: [
-                    IconButton(
-                        alignment: Alignment.topLeft,
-                        tooltip: "About Bison Relay",
-                        iconSize: 50,
-                        onPressed: goToAbout,
-                        icon: Image.asset(
-                          "assets/images/icon.png",
-                        )),
-                  ]),
-                  const SizedBox(height: 39),
-                  Text("Setting up Bison Relay",
-                      style: TextStyle(
-                          color: textColor,
-                          fontSize: theme.getHugeFont(context),
-                          fontWeight: FontWeight.w200)),
-                  const SizedBox(height: 20),
-                  Text("Confirm New Wallet Seed",
-                      style: TextStyle(
-                          color: secondaryTextColor,
-                          fontSize: theme.getLargeFont(context),
-                          fontWeight: FontWeight.w300)),
-                  const SizedBox(height: 34),
-                  Center(
-                    child: SizedBox(
-                        width: 519,
-                        child: Wrap(spacing: 5, runSpacing: 5, children: [
-                          for (var i in seedWords)
-                            i != ""
-                                ? Container(
-                                    padding: const EdgeInsets.only(
-                                        left: 8, top: 3, right: 8, bottom: 3),
-                                    color: backgroundColor,
-                                    child: Text(i,
-                                        style: TextStyle(
-                                            color: textColor,
-                                            fontSize:
-                                                theme.getMediumFont(context),
-                                            fontWeight: FontWeight.w300)))
-                                : const Empty()
-                        ])),
-                  ),
-                  const SizedBox(height: 10),
-                  TextButton(
-                    onPressed: () => copySeedToClipboard(context),
-                    child: Text("Copy to Clipboard",
-                        style: TextStyle(color: textColor)),
-                  ),
-                  /*   XXX NEED TO FIGURE OUT LISTVIEW within a row FOR SEED WORD BUBBLES
+    return StartupScreen(Consumer<ThemeNotifier>(
+      builder: (context, theme, _) => Column(children: [
+        Row(children: [
+          IconButton(
+              alignment: Alignment.topLeft,
+              tooltip: "About Bison Relay",
+              iconSize: 50,
+              onPressed: goToAbout,
+              icon: Image.asset(
+                "assets/images/icon.png",
+              )),
+        ]),
+        const SizedBox(height: 39),
+        Text("Setting up Bison Relay",
+            style: TextStyle(
+                color: theme.getTheme().dividerColor,
+                fontSize: theme.getHugeFont(context),
+                fontWeight: FontWeight.w200)),
+        const SizedBox(height: 20),
+        Text("Confirm New Wallet Seed",
+            style: TextStyle(
+                color: theme.getTheme().focusColor,
+                fontSize: theme.getLargeFont(context),
+                fontWeight: FontWeight.w300)),
+        const SizedBox(height: 34),
+        Center(
+          child: SizedBox(
+              width: 519,
+              child: Wrap(spacing: 5, runSpacing: 5, children: [
+                for (var i in seedWords)
+                  i != ""
+                      ? Container(
+                          padding: const EdgeInsets.only(
+                              left: 8, top: 3, right: 8, bottom: 3),
+                          color: backgroundColor,
+                          child: Text(i,
+                              style: TextStyle(
+                                  color: theme.getTheme().dividerColor,
+                                  fontSize: theme.getMediumFont(context),
+                                  fontWeight: FontWeight.w300)))
+                      : const Empty()
+              ])),
+        ),
+        const SizedBox(height: 10),
+        TextButton(
+          onPressed: () => copySeedToClipboard(context),
+          child: Text("Copy to Clipboard",
+              style: TextStyle(color: theme.getTheme().dividerColor)),
+        ),
+        /*   XXX NEED TO FIGURE OUT LISTVIEW within a row FOR SEED WORD BUBBLES
               Expanded(
                   child: ListView.builder(
                 shrinkWrap: true,
@@ -117,18 +90,17 @@ class NewLNWalletSeedPage extends StatelessWidget {
                     color: backgroundColor,
                     child: Text(seedWords[index],
                         style: TextStyle(
-                            color: textColor,
+                            color: theme.getTheme().dividerColor,
                             fontSize: theme.getMediumFont(context),
                             fontWeight: FontWeight.w300))),
               )),
               */
-                  const SizedBox(height: 34),
-                  LoadingScreenButton(
-                    onPressed: done,
-                    text: "I have copied the seed",
-                  ),
-                ]),
-              )
-            ])));
+        const SizedBox(height: 34),
+        LoadingScreenButton(
+          onPressed: done,
+          text: "I have copied the seed",
+        ),
+      ]),
+    ));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/newconfig/ln_wallet_seed.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/ln_wallet_seed.dart
@@ -26,7 +26,6 @@ class NewLNWalletSeedPage extends StatelessWidget {
       Navigator.of(context).pushNamed("/about");
     }
 
-    var backgroundColor = const Color(0xFF19172C);
     var seedWords = newconf.newWalletSeed.split(' ');
 
     return StartupScreen(Consumer<ThemeNotifier>(
@@ -63,7 +62,7 @@ class NewLNWalletSeedPage extends StatelessWidget {
                       ? Container(
                           padding: const EdgeInsets.only(
                               left: 8, top: 3, right: 8, bottom: 3),
-                          color: backgroundColor,
+                          color: theme.getTheme().backgroundColor,
                           child: Text(i,
                               style: TextStyle(
                                   color: theme.getTheme().dividerColor,
@@ -87,7 +86,7 @@ class NewLNWalletSeedPage extends StatelessWidget {
                     margin: EdgeInsets.all(5),
                     padding:
                         EdgeInsets.only(left: 8, top: 3, right: 8, bottom: 3),
-                    color: backgroundColor,
+                    color: theme.getTheme().backgroundColor,
                     child: Text(seedWords[index],
                         style: TextStyle(
                             color: theme.getTheme().dividerColor,

--- a/bruig/flutterui/bruig/lib/screens/newconfig/ln_wallet_seed_confirm.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/ln_wallet_seed_confirm.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:bruig/models/newconfig.dart';
+import 'package:bruig/screens/startupscreen.dart';
 import 'package:flutter/material.dart';
 import 'package:bruig/components/buttons.dart';
 import 'package:provider/provider.dart';
@@ -55,88 +56,60 @@ class _ConfirmLNWalletSeedPageState extends State<ConfirmLNWalletSeedPage> {
       Navigator.of(context).pushNamed("/about");
     }
 
-    var backgroundColor = const Color(0xFF19172C);
-    var cardColor = const Color(0xFF05031A);
     var textColor = const Color(0xFF8E8D98);
     var secondaryTextColor = const Color(0xFFE4E3E6);
     var confirmSeedWords = widget.newconf.confirmSeedWords;
 
-    return Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => Container(
-            color: backgroundColor,
-            child: Stack(children: [
-              Container(
-                  decoration: const BoxDecoration(
-                      image: DecorationImage(
-                          fit: BoxFit.fill,
-                          image: AssetImage("assets/images/loading-bg.png")))),
-              Container(
-                decoration: BoxDecoration(
-                    gradient: LinearGradient(
-                        begin: Alignment.bottomLeft,
-                        end: Alignment.topRight,
-                        colors: [
-                      cardColor,
-                      const Color(0xFF07051C),
-                      backgroundColor.withOpacity(0.34),
-                    ],
-                        stops: const [
-                      0,
-                      0.17,
-                      1
-                    ])),
-                padding: const EdgeInsets.all(10),
-                child: Column(children: [
-                  Row(children: [
-                    IconButton(
-                        alignment: Alignment.topLeft,
-                        tooltip: "About Bison Relay",
-                        iconSize: 50,
-                        onPressed: goToAbout,
-                        icon: Image.asset(
-                          "assets/images/icon.png",
-                        )),
-                  ]),
-                  const SizedBox(height: 39),
-                  Text("Setting up Bison Relay",
+    return StartupScreen(Consumer<ThemeNotifier>(
+      builder: (context, theme, _) => Column(children: [
+        Row(children: [
+          IconButton(
+              alignment: Alignment.topLeft,
+              tooltip: "About Bison Relay",
+              iconSize: 50,
+              onPressed: goToAbout,
+              icon: Image.asset(
+                "assets/images/icon.png",
+              )),
+        ]),
+        const SizedBox(height: 39),
+        Text("Setting up Bison Relay",
+            style: TextStyle(
+                color: textColor,
+                fontSize: theme.getHugeFont(context),
+                fontWeight: FontWeight.w200)),
+        const SizedBox(height: 20),
+        Text("Confirm New Wallet Seed",
+            style: TextStyle(
+                color: secondaryTextColor,
+                fontSize: theme.getLargeFont(context),
+                fontWeight: FontWeight.w300)),
+        const SizedBox(height: 34),
+        AnimatedOpacity(
+          opacity: _visible ? 1.0 : 0.0,
+          duration: const Duration(milliseconds: 500),
+          child: currentQuestion < confirmSeedWords.length
+              ? !answerWrong
+                  ? QuestionArea(confirmSeedWords[currentQuestion], checkAnswer)
+                  : IncorrectArea(goBack)
+              : Column(children: [
+                  Text("Seed Confirmed",
                       style: TextStyle(
                           color: textColor,
-                          fontSize: theme.getHugeFont(context),
+                          fontSize: theme.getLargeFont(context),
                           fontWeight: FontWeight.w200)),
                   const SizedBox(height: 20),
-                  Text("Confirm New Wallet Seed",
-                      style: TextStyle(
-                          color: secondaryTextColor,
-                          fontSize: theme.getLargeFont(context),
-                          fontWeight: FontWeight.w300)),
-                  const SizedBox(height: 34),
-                  AnimatedOpacity(
-                    opacity: _visible ? 1.0 : 0.0,
-                    duration: const Duration(milliseconds: 500),
-                    child: currentQuestion < confirmSeedWords.length
-                        ? !answerWrong
-                            ? QuestionArea(
-                                confirmSeedWords[currentQuestion], checkAnswer)
-                            : IncorrectArea(goBack)
-                        : Column(children: [
-                            Text("Seed Confirmed",
-                                style: TextStyle(
-                                    color: textColor,
-                                    fontSize: theme.getLargeFont(context),
-                                    fontWeight: FontWeight.w200)),
-                            const SizedBox(height: 20),
-                            Center(
-                                child: LoadingScreenButton(
-                              onPressed: done,
-                              text: "Continue",
-                            ))
-                          ]),
-                  ),
-                  const SizedBox(height: 10),
-                  const SizedBox(height: 34),
+                  Center(
+                      child: LoadingScreenButton(
+                    onPressed: done,
+                    text: "Continue",
+                  ))
                 ]),
-              )
-            ])));
+        ),
+        const SizedBox(height: 10),
+        const SizedBox(height: 34),
+      ]),
+    ));
   }
 }
 

--- a/bruig/flutterui/bruig/lib/screens/newconfig/ln_wallet_seed_confirm.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/ln_wallet_seed_confirm.dart
@@ -56,8 +56,6 @@ class _ConfirmLNWalletSeedPageState extends State<ConfirmLNWalletSeedPage> {
       Navigator.of(context).pushNamed("/about");
     }
 
-    var textColor = const Color(0xFF8E8D98);
-    var secondaryTextColor = const Color(0xFFE4E3E6);
     var confirmSeedWords = widget.newconf.confirmSeedWords;
 
     return StartupScreen(Consumer<ThemeNotifier>(
@@ -75,13 +73,13 @@ class _ConfirmLNWalletSeedPageState extends State<ConfirmLNWalletSeedPage> {
         const SizedBox(height: 39),
         Text("Setting up Bison Relay",
             style: TextStyle(
-                color: textColor,
+                color: theme.getTheme().dividerColor,
                 fontSize: theme.getHugeFont(context),
                 fontWeight: FontWeight.w200)),
         const SizedBox(height: 20),
         Text("Confirm New Wallet Seed",
             style: TextStyle(
-                color: secondaryTextColor,
+                color: theme.getTheme().focusColor,
                 fontSize: theme.getLargeFont(context),
                 fontWeight: FontWeight.w300)),
         const SizedBox(height: 34),
@@ -95,7 +93,7 @@ class _ConfirmLNWalletSeedPageState extends State<ConfirmLNWalletSeedPage> {
               : Column(children: [
                   Text("Seed Confirmed",
                       style: TextStyle(
-                          color: textColor,
+                          color: theme.getTheme().dividerColor,
                           fontSize: theme.getLargeFont(context),
                           fontWeight: FontWeight.w200)),
                   const SizedBox(height: 20),
@@ -122,13 +120,12 @@ class QuestionArea extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     bool isScreenSmall = MediaQuery.of(context).size.width <= 500;
-    var textColor = const Color(0xFF8E8D98);
     return Consumer<ThemeNotifier>(
         builder: (context, theme, _) => Column(children: [
               Center(
                   child: Text("Word #${currentWords.position + 1}",
                       style: TextStyle(
-                          color: textColor,
+                          color: theme.getTheme().dividerColor,
                           fontSize: theme.getHugeFont(context),
                           fontWeight: FontWeight.w200))),
               const SizedBox(height: 20),
@@ -157,7 +154,6 @@ class IncorrectArea extends StatelessWidget {
   const IncorrectArea(this.goBackCB, {Key? key}) : super(key: key);
   @override
   Widget build(BuildContext context) {
-    var textColor = const Color(0xFF8E8D98);
     return Consumer<ThemeNotifier>(
         builder: (context, theme, _) => Column(children: [
               Center(
@@ -165,7 +161,7 @@ class IncorrectArea extends StatelessWidget {
                       "Incorrect, please go back and copy the seed again.",
                       textAlign: TextAlign.center,
                       style: TextStyle(
-                          color: textColor,
+                          color: theme.getTheme().dividerColor,
                           fontSize: theme.getLargeFont(context),
                           fontWeight: FontWeight.w200))),
               const SizedBox(height: 20),

--- a/bruig/flutterui/bruig/lib/screens/newconfig/move_old_version.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/move_old_version.dart
@@ -3,6 +3,7 @@ import 'package:bruig/components/copyable.dart';
 import 'package:bruig/components/snackbars.dart';
 import 'package:bruig/config.dart';
 import 'package:bruig/models/newconfig.dart';
+import 'package:bruig/screens/startupscreen.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:bruig/theme_manager.dart';
@@ -57,135 +58,105 @@ class _MoveOldVersionWalletPageState extends State<MoveOldVersionWalletPage> {
 
   @override
   Widget build(BuildContext context) {
-    var backgroundColor = const Color(0xFF19172C);
-    var cardColor = const Color(0xFF05031A);
-    var textColor = const Color(0xFF8E8D98);
-
     void goToAbout() {
       Navigator.of(context).pushNamed("/about");
     }
 
-    return Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => Container(
-            color: backgroundColor,
-            child: Stack(children: [
-              Container(
-                  decoration: const BoxDecoration(
-                      image: DecorationImage(
-                          fit: BoxFit.fill,
-                          image: AssetImage("assets/images/loading-bg.png")))),
-              Container(
-                  decoration: BoxDecoration(
-                      gradient: LinearGradient(
-                          begin: Alignment.bottomLeft,
-                          end: Alignment.topRight,
-                          colors: [
-                        cardColor,
-                        const Color(0xFF07051C),
-                        backgroundColor.withOpacity(0.34),
-                      ],
-                          stops: const [
-                        0,
-                        0.17,
-                        1
-                      ])),
-                  padding: const EdgeInsets.all(10),
-                  child: Column(children: [
-                    Row(children: [
-                      IconButton(
-                          alignment: Alignment.topLeft,
-                          tooltip: "About Bison Relay",
-                          iconSize: 50,
-                          onPressed: goToAbout,
-                          icon: Image.asset(
-                            "assets/images/icon.png",
-                          )),
-                    ]),
-                    const SizedBox(height: 39),
-                    unableToMove
-                        ? Column(children: [
-                            Text("Move old wallet",
-                                style: TextStyle(
-                                    color: textColor,
-                                    fontSize: theme.getHugeFont(context),
-                                    fontWeight: FontWeight.w200)),
-                            const SizedBox(height: 20),
-                            SizedBox(
-                                width: 377,
-                                child: Text(_errorMoveMsg,
-                                    textAlign: TextAlign.left,
+    return StartupScreen(Consumer<ThemeNotifier>(
+        builder: (context, theme, _) => Column(children: [
+              Row(children: [
+                IconButton(
+                    alignment: Alignment.topLeft,
+                    tooltip: "About Bison Relay",
+                    iconSize: 50,
+                    onPressed: goToAbout,
+                    icon: Image.asset(
+                      "assets/images/icon.png",
+                    )),
+              ]),
+              const SizedBox(height: 39),
+              unableToMove
+                  ? Column(children: [
+                      Text("Move old wallet",
+                          style: TextStyle(
+                              color: theme.getTheme().dividerColor,
+                              fontSize: theme.getHugeFont(context),
+                              fontWeight: FontWeight.w200)),
+                      const SizedBox(height: 20),
+                      SizedBox(
+                          width: 377,
+                          child: Text(_errorMoveMsg,
+                              textAlign: TextAlign.left,
+                              style: TextStyle(
+                                  color: theme.getTheme().dividerColor,
+                                  fontSize: theme.getMediumFont(context),
+                                  fontWeight: FontWeight.w300))),
+                    ])
+                  : Column(children: [
+                      Text("Move old wallet",
+                          style: TextStyle(
+                              color: theme.getTheme().dividerColor,
+                              fontSize: theme.getHugeFont(context),
+                              fontWeight: FontWeight.w200)),
+                      const SizedBox(height: 20),
+                      Column(children: [
+                        SizedBox(
+                            width: 377,
+                            child: Column(children: [
+                              Text(_warnMsg1,
+                                  textAlign: TextAlign.left,
+                                  style: TextStyle(
+                                      color: theme.getTheme().dividerColor,
+                                      fontSize: theme.getMediumFont(context),
+                                      fontWeight: FontWeight.w300)),
+                              Copyable(
+                                  _warnMsg2,
+                                  TextStyle(
+                                      color: theme.getTheme().dividerColor,
+                                      fontSize: theme.getMediumFont(context),
+                                      fontWeight: FontWeight.w300)),
+                              Text(_warnMsg3,
+                                  textAlign: TextAlign.left,
+                                  style: TextStyle(
+                                      color: theme.getTheme().dividerColor,
+                                      fontSize: theme.getMediumFont(context),
+                                      fontWeight: FontWeight.w300))
+                            ])),
+                        Center(
+                          child: SizedBox(
+                              width: 377,
+                              child: CheckboxListTile(
+                                title: Text(
+                                    "Directory has been backed up or proceed without backing up",
                                     style: TextStyle(
-                                        color: textColor,
-                                        fontSize: theme.getMediumFont(context),
-                                        fontWeight: FontWeight.w300))),
-                          ])
-                        : Column(children: [
-                            Text("Move old wallet",
-                                style: TextStyle(
-                                    color: textColor,
-                                    fontSize: theme.getHugeFont(context),
-                                    fontWeight: FontWeight.w200)),
-                            const SizedBox(height: 20),
-                            Column(children: [
-                              SizedBox(
-                                  width: 377,
-                                  child: Column(children: [
-                                    Text(_warnMsg1,
-                                        textAlign: TextAlign.left,
-                                        style: TextStyle(
-                                            color: textColor,
-                                            fontSize:
-                                                theme.getMediumFont(context),
-                                            fontWeight: FontWeight.w300)),
-                                    Copyable(
-                                        _warnMsg2,
-                                        TextStyle(
-                                            color: textColor,
-                                            fontSize:
-                                                theme.getMediumFont(context),
-                                            fontWeight: FontWeight.w300)),
-                                    Text(_warnMsg3,
-                                        textAlign: TextAlign.left,
-                                        style: TextStyle(
-                                            color: textColor,
-                                            fontSize:
-                                                theme.getMediumFont(context),
-                                            fontWeight: FontWeight.w300))
-                                  ])),
-                              Center(
-                                child: SizedBox(
-                                    width: 377,
-                                    child: CheckboxListTile(
-                                      title: Text(
-                                          "Directory has been backed up or proceed without backing up",
-                                          style: TextStyle(color: textColor)),
-                                      activeColor: textColor,
-                                      value: moveAcccepted,
-                                      side: BorderSide(color: textColor),
-                                      onChanged: (val) {
-                                        setState(() {
-                                          moveAcccepted = val ?? false;
-                                        });
-                                      },
-                                    )),
-                              ),
-                              const SizedBox(height: 34),
-                              Center(
-                                  child: SizedBox(
-                                      width: 278,
-                                      child: Row(children: [
-                                        const SizedBox(width: 35),
-                                        LoadingScreenButton(
-                                          onPressed: moveAcccepted && !moving
-                                              ? () => moveOldVersion(context)
-                                              : null,
-                                          text: "Move Wallet",
-                                        ),
-                                        const SizedBox(width: 10),
-                                      ])))
-                            ]),
-                          ])
-                  ]))
+                                        color: theme.getTheme().dividerColor)),
+                                activeColor: theme.getTheme().dividerColor,
+                                value: moveAcccepted,
+                                side: BorderSide(
+                                    color: theme.getTheme().dividerColor),
+                                onChanged: (val) {
+                                  setState(() {
+                                    moveAcccepted = val ?? false;
+                                  });
+                                },
+                              )),
+                        ),
+                        const SizedBox(height: 34),
+                        Center(
+                            child: SizedBox(
+                                width: 278,
+                                child: Row(children: [
+                                  const SizedBox(width: 35),
+                                  LoadingScreenButton(
+                                    onPressed: moveAcccepted && !moving
+                                        ? () => moveOldVersion(context)
+                                        : null,
+                                    text: "Move Wallet",
+                                  ),
+                                  const SizedBox(width: 10),
+                                ])))
+                      ]),
+                    ])
             ])));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/newconfig/network_choice.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/network_choice.dart
@@ -1,4 +1,5 @@
 import 'package:bruig/models/newconfig.dart';
+import 'package:bruig/screens/startupscreen.dart';
 import 'package:flutter/material.dart';
 import 'package:bruig/components/buttons.dart';
 import 'package:provider/provider.dart';
@@ -21,97 +22,66 @@ class NetworkChoicePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     bool isScreenSmall = MediaQuery.of(context).size.width <= 500;
-    var backgroundColor = const Color(0xFF19172C);
-    var cardColor = const Color(0xFF05031A);
-    var textColor = const Color(0xFF8E8D98);
-    var secondaryTextColor = const Color(0xFFE4E3E6);
-
     void goToAbout() {
       Navigator.of(context).pushNamed("/about");
     }
 
-    return Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => Container(
-            color: backgroundColor,
-            child: Stack(children: [
-              Container(
-                  decoration: const BoxDecoration(
-                      image: DecorationImage(
-                          fit: BoxFit.fill,
-                          image: AssetImage("assets/images/loading-bg.png")))),
-              Container(
-                  decoration: BoxDecoration(
-                      gradient: LinearGradient(
-                          begin: Alignment.bottomLeft,
-                          end: Alignment.topRight,
-                          colors: [
-                        cardColor,
-                        const Color(0xFF07051C),
-                        backgroundColor.withOpacity(0.34),
-                      ],
-                          stops: const [
-                        0,
-                        0.17,
-                        1
-                      ])),
-                  padding: const EdgeInsets.all(10),
-                  child: Column(children: [
-                    Row(children: [
-                      IconButton(
-                          alignment: Alignment.topLeft,
-                          tooltip: "About Bison Relay",
-                          iconSize: 50,
-                          onPressed: goToAbout,
-                          icon: Image.asset(
-                            "assets/images/icon.png",
-                          )),
-                    ]),
-                    //const SizedBox(height: 208),
-                    Text("Setting up Bison Relay",
-                        style: TextStyle(
-                            color: textColor,
-                            fontSize: theme.getHugeFont(context),
-                            fontWeight: FontWeight.w200)),
-                    const SizedBox(height: 20),
-                    Text("Choose Network",
-                        style: TextStyle(
-                            color: secondaryTextColor,
-                            fontSize: theme.getMediumFont(context),
-                            fontWeight: FontWeight.w300)),
-                    const SizedBox(height: 34),
-                    Flex(
-                        direction:
-                            isScreenSmall ? Axis.vertical : Axis.horizontal,
-                        crossAxisAlignment: CrossAxisAlignment.center,
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          LoadingScreenButton(
-                              onPressed: () =>
-                                  setChoice(context, NetworkType.mainnet),
-                              text: "Mainnet",
-                              empty: true),
-                          isScreenSmall
-                              ? const SizedBox(height: 13)
-                              : const SizedBox(width: 13),
-                          LoadingScreenButton(
-                              onPressed: () =>
-                                  setChoice(context, NetworkType.testnet),
-                              text: "Testnet",
-                              empty: true),
-                          isScreenSmall
-                              ? const SizedBox(height: 13)
-                              : const SizedBox(width: 13),
-                          LoadingScreenButton(
-                              onPressed: () =>
-                                  setChoice(context, NetworkType.simnet),
-                              text: "Simnet",
-                              empty: true),
-                        ])
-                  ])),
+    return StartupScreen(Consumer<ThemeNotifier>(
+        builder: (context, theme, _) => Column(children: [
+              Row(children: [
+                IconButton(
+                    alignment: Alignment.topLeft,
+                    tooltip: "About Bison Relay",
+                    iconSize: 50,
+                    onPressed: goToAbout,
+                    icon: Image.asset(
+                      "assets/images/icon.png",
+                    )),
+              ]),
+              //const SizedBox(height: 208),
+              Text("Setting up Bison Relay",
+                  style: TextStyle(
+                      color: theme.getTheme().dividerColor,
+                      fontSize: theme.getHugeFont(context),
+                      fontWeight: FontWeight.w200)),
+              const SizedBox(height: 20),
+              Text("Choose Network",
+                  style: TextStyle(
+                      color: theme.getTheme().focusColor,
+                      fontSize: theme.getMediumFont(context),
+                      fontWeight: FontWeight.w300)),
+              const SizedBox(height: 34),
+              Flex(
+                  direction: isScreenSmall ? Axis.vertical : Axis.horizontal,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    LoadingScreenButton(
+                        onPressed: () =>
+                            setChoice(context, NetworkType.mainnet),
+                        text: "Mainnet",
+                        empty: true),
+                    isScreenSmall
+                        ? const SizedBox(height: 13)
+                        : const SizedBox(width: 13),
+                    LoadingScreenButton(
+                        onPressed: () =>
+                            setChoice(context, NetworkType.testnet),
+                        text: "Testnet",
+                        empty: true),
+                    isScreenSmall
+                        ? const SizedBox(height: 13)
+                        : const SizedBox(width: 13),
+                    LoadingScreenButton(
+                        onPressed: () => setChoice(context, NetworkType.simnet),
+                        text: "Simnet",
+                        empty: true),
+                  ]),
               Row(mainAxisAlignment: MainAxisAlignment.center, children: [
                 TextButton(
                   onPressed: () => goBack(context),
-                  child: Text("Go Back", style: TextStyle(color: textColor)),
+                  child: Text("Go Back",
+                      style: TextStyle(color: theme.getTheme().dividerColor)),
                 )
               ])
             ])));

--- a/bruig/flutterui/bruig/lib/screens/newconfig/restore_wallet.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/restore_wallet.dart
@@ -4,6 +4,7 @@ import 'package:bruig/components/buttons.dart';
 import 'package:bruig/components/empty_widget.dart';
 import 'package:bruig/components/snackbars.dart';
 import 'package:bruig/models/newconfig.dart';
+import 'package:bruig/screens/startupscreen.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -67,113 +68,82 @@ class _RestoreWalletPageState extends State<RestoreWalletPage> {
 
   @override
   Widget build(BuildContext context) {
-    var backgroundColor = const Color(0xFF19172C);
-    var cardColor = const Color(0xFF05031A);
-    var textColor = const Color(0xFF8E8D98);
-    var secondaryTextColor = const Color(0xFFE4E3E6);
-    var darkTextColor = const Color(0xFF5A5968);
-
     void goToAbout() {
       Navigator.of(context).pushNamed("/about");
     }
 
-    return Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => Container(
-            color: backgroundColor,
-            child: Stack(children: [
-              Container(
-                  decoration: const BoxDecoration(
-                      image: DecorationImage(
-                          fit: BoxFit.fill,
-                          image: AssetImage("assets/images/loading-bg.png")))),
-              Container(
-                  decoration: BoxDecoration(
-                      gradient: LinearGradient(
-                          begin: Alignment.bottomLeft,
-                          end: Alignment.topRight,
-                          colors: [
-                        cardColor,
-                        const Color(0xFF07051C),
-                        backgroundColor.withOpacity(0.34),
-                      ],
-                          stops: const [
-                        0,
-                        0.17,
-                        1
-                      ])),
-                  padding: const EdgeInsets.all(10),
-                  child: Column(children: [
-                    Row(children: [
-                      IconButton(
-                          alignment: Alignment.topLeft,
-                          tooltip: "About Bison Relay",
-                          iconSize: 50,
-                          onPressed: goToAbout,
-                          icon: Image.asset(
-                            "assets/images/icon.png",
-                          )),
-                    ]),
-                    const SizedBox(height: 39),
-                    Text("Restoring wallet",
-                        style: TextStyle(
-                            color: textColor,
-                            fontSize: theme.getHugeFont(context),
-                            fontWeight: FontWeight.w200)),
-                    const SizedBox(height: 20),
-                    SizedBox(
-                        width: 577,
-                        child: Text("Seed Words",
-                            textAlign: TextAlign.left,
-                            style: TextStyle(
-                                color: darkTextColor,
-                                fontSize: theme.getMediumFont(context),
-                                fontWeight: FontWeight.w300))),
-                    Center(
-                        child: SizedBox(
-                            width: 577,
-                            child: TextField(
-                                maxLines: 5,
-                                cursorColor: secondaryTextColor,
-                                decoration: InputDecoration(
-                                    border: InputBorder.none,
-                                    hintText: "Seed words",
-                                    hintStyle: TextStyle(
-                                        fontSize: theme.getLargeFont(context),
-                                        color: textColor),
-                                    filled: true,
-                                    fillColor: cardColor),
-                                style: TextStyle(
-                                    color: secondaryTextColor,
-                                    fontSize: theme.getLargeFont(context)),
-                                controller: seedCtrl))),
-                    const SizedBox(height: 10),
-                    Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          TextButton(
-                            onPressed: selectSCB,
-                            child: Text(
-                              "Select optional SCB file To Restore",
-                              style: TextStyle(color: textColor),
-                            ),
-                          ),
-                          scbFilename.isNotEmpty
-                              ? Text(scbFilename,
-                                  style: TextStyle(color: darkTextColor))
-                              : const Empty(),
-                        ]),
-                    const SizedBox(height: 34),
-                    Row(mainAxisAlignment: MainAxisAlignment.center, children: [
-                      LoadingScreenButton(
-                        onPressed: useSeed,
-                        text: "Continue",
-                      ),
-                    ]),
-                  ])),
+    return StartupScreen(Consumer<ThemeNotifier>(
+        builder: (context, theme, _) => Column(children: [
+              Row(children: [
+                IconButton(
+                    alignment: Alignment.topLeft,
+                    tooltip: "About Bison Relay",
+                    iconSize: 50,
+                    onPressed: goToAbout,
+                    icon: Image.asset(
+                      "assets/images/icon.png",
+                    )),
+              ]),
+              const SizedBox(height: 39),
+              Text("Restoring wallet",
+                  style: TextStyle(
+                      color: theme.getTheme().dividerColor,
+                      fontSize: theme.getHugeFont(context),
+                      fontWeight: FontWeight.w200)),
+              const SizedBox(height: 20),
+              SizedBox(
+                  width: 577,
+                  child: Text("Seed Words",
+                      textAlign: TextAlign.left,
+                      style: TextStyle(
+                          color: theme.getTheme().indicatorColor,
+                          fontSize: theme.getMediumFont(context),
+                          fontWeight: FontWeight.w300))),
+              Center(
+                  child: SizedBox(
+                      width: 577,
+                      child: TextField(
+                          maxLines: 5,
+                          cursorColor: theme.getTheme().focusColor,
+                          decoration: InputDecoration(
+                              border: InputBorder.none,
+                              hintText: "Seed words",
+                              hintStyle: TextStyle(
+                                  fontSize: theme.getLargeFont(context),
+                                  color: theme.getTheme().dividerColor),
+                              filled: true,
+                              fillColor: theme.getTheme().cardColor),
+                          style: TextStyle(
+                              color: theme.getTheme().focusColor,
+                              fontSize: theme.getLargeFont(context)),
+                          controller: seedCtrl))),
+              const SizedBox(height: 10),
+              Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+                TextButton(
+                  onPressed: selectSCB,
+                  child: Text(
+                    "Select optional SCB file To Restore",
+                    style: TextStyle(color: theme.getTheme().dividerColor),
+                  ),
+                ),
+                scbFilename.isNotEmpty
+                    ? Text(scbFilename,
+                        style:
+                            TextStyle(color: theme.getTheme().indicatorColor))
+                    : const Empty(),
+              ]),
+              const SizedBox(height: 34),
+              Row(mainAxisAlignment: MainAxisAlignment.center, children: [
+                LoadingScreenButton(
+                  onPressed: useSeed,
+                  text: "Continue",
+                ),
+              ]),
               Row(mainAxisAlignment: MainAxisAlignment.center, children: [
                 TextButton(
                   onPressed: () => goBack(context),
-                  child: Text("Go Back", style: TextStyle(color: textColor)),
+                  child: Text("Go Back",
+                      style: TextStyle(color: theme.getTheme().dividerColor)),
                 )
               ])
             ])));

--- a/bruig/flutterui/bruig/lib/screens/newconfig/server.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/server.dart
@@ -2,6 +2,7 @@ import 'package:bruig/components/snackbars.dart';
 import 'package:bruig/components/buttons.dart';
 import 'package:bruig/main.dart';
 import 'package:bruig/models/newconfig.dart';
+import 'package:bruig/screens/startupscreen.dart';
 import 'package:bruig/screens/unlock_ln.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -51,92 +52,60 @@ class _ServerPageState extends State<ServerPage> {
 
   @override
   Widget build(BuildContext context) {
-    var backgroundColor = const Color(0xFF19172C);
-    var cardColor = const Color(0xFF05031A);
-    var textColor = const Color(0xFF8E8D98);
-    var secondaryTextColor = const Color(0xFFE4E3E6);
-
     void goToAbout() {
       Navigator.of(context).pushNamed("/about");
     }
 
-    return Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => Container(
-            color: backgroundColor,
-            child: Stack(children: [
-              Container(
-                  decoration: const BoxDecoration(
-                      image: DecorationImage(
-                          fit: BoxFit.fill,
-                          image: AssetImage("assets/images/loading-bg.png")))),
-              Container(
-                  decoration: BoxDecoration(
-                      gradient: LinearGradient(
-                          begin: Alignment.bottomLeft,
-                          end: Alignment.topRight,
-                          colors: [
-                        cardColor,
-                        const Color(0xFF07051C),
-                        backgroundColor.withOpacity(0.34),
-                      ],
-                          stops: const [
-                        0,
-                        0.17,
-                        1
-                      ])),
-                  padding: const EdgeInsets.all(10),
-                  child: Column(children: [
-                    Row(children: [
-                      IconButton(
-                          alignment: Alignment.topLeft,
-                          tooltip: "About Bison Relay",
-                          iconSize: 50,
-                          onPressed: goToAbout,
-                          icon: Image.asset(
-                            "assets/images/icon.png",
-                          )),
-                    ]),
-                    const SizedBox(height: 39),
-                    Text("Setting up Bison Relay",
-                        style: TextStyle(
-                            color: textColor,
-                            fontSize: theme.getHugeFont(context),
-                            fontWeight: FontWeight.w200)),
-                    const SizedBox(height: 20),
-                    Text("Connect to Server",
-                        style: TextStyle(
-                            color: secondaryTextColor,
-                            fontSize: theme.getLargeFont(context),
-                            fontWeight: FontWeight.w300)),
-                    const SizedBox(height: 34),
-                    Row(children: [
-                      Flexible(
-                          child: Align(
-                              child: SizedBox(
-                                  width: 300,
-                                  child: TextField(
-                                      cursorColor: secondaryTextColor,
-                                      decoration: InputDecoration(
-                                          border: InputBorder.none,
-                                          hintText: "RPC Host",
-                                          hintStyle: TextStyle(
-                                              fontSize:
-                                                  theme.getMediumFont(context),
-                                              color: textColor),
-                                          filled: true,
-                                          fillColor: cardColor),
-                                      style: TextStyle(
-                                          color: textColor,
-                                          fontSize:
-                                              theme.getMediumFont(context)),
-                                      controller: serverCtrl)))),
-                    ]),
-                    const SizedBox(height: 34),
-                    LoadingScreenButton(
-                      onPressed: done,
-                      text: "Connect",
-                    ),
-                  ]))
+    return StartupScreen(Consumer<ThemeNotifier>(
+        builder: (context, theme, _) => Column(children: [
+              Row(children: [
+                IconButton(
+                    alignment: Alignment.topLeft,
+                    tooltip: "About Bison Relay",
+                    iconSize: 50,
+                    onPressed: goToAbout,
+                    icon: Image.asset(
+                      "assets/images/icon.png",
+                    )),
+              ]),
+              const SizedBox(height: 39),
+              Text("Setting up Bison Relay",
+                  style: TextStyle(
+                      color: theme.getTheme().dividerColor,
+                      fontSize: theme.getHugeFont(context),
+                      fontWeight: FontWeight.w200)),
+              const SizedBox(height: 20),
+              Text("Connect to Server",
+                  style: TextStyle(
+                      color: theme.getTheme().focusColor,
+                      fontSize: theme.getLargeFont(context),
+                      fontWeight: FontWeight.w300)),
+              const SizedBox(height: 34),
+              Row(children: [
+                Flexible(
+                    child: Align(
+                        child: SizedBox(
+                            width: 300,
+                            child: TextField(
+                                cursorColor: theme.getTheme().focusColor,
+                                decoration: InputDecoration(
+                                    border: InputBorder.none,
+                                    hintText: "RPC Host",
+                                    hintStyle: TextStyle(
+                                        fontSize: theme.getMediumFont(context),
+                                        color: theme.getTheme().dividerColor),
+                                    filled: true,
+                                    fillColor: theme.getTheme().cardColor),
+                                style: TextStyle(
+                                    color: theme.getTheme().dividerColor,
+                                    fontSize: theme.getMediumFont(context)),
+                                controller: serverCtrl)))),
+              ]),
+              const SizedBox(height: 34),
+              LoadingScreenButton(
+                onPressed: done,
+                text: "Connect",
+              ),
             ])));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/onboarding.dart
+++ b/bruig/flutterui/bruig/lib/screens/onboarding.dart
@@ -173,11 +173,6 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
 
   @override
   Widget build(BuildContext context) {
-    var backgroundColor = const Color(0xFF19172C);
-    var cardColor = const Color(0xFF05031A);
-    var textColor = const Color(0xFF8E8D98);
-    var errorColor = const Color(0xFFFF0000);
-
     void goToAbout() {
       Navigator.of(context).pushNamed("/about");
     }
@@ -185,7 +180,10 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     List<Widget> children;
     if (readingState) {
       children = [
-        Text("Reading onboarding state...", style: TextStyle(color: textColor))
+        Consumer<ThemeNotifier>(
+            builder: (context, theme, child) => Text(
+                "Reading onboarding state...",
+                style: TextStyle(color: theme.getTheme().dividerColor)))
       ];
     } else if (ostate == null) {
       children = [
@@ -204,19 +202,28 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
       ];
     } else if (starting) {
       children = [
-        Text("Starting onboarding procedure...",
-            style: TextStyle(color: textColor))
+        Consumer<ThemeNotifier>(
+            builder: (context, theme, child) => Text(
+                "Starting onboarding procedure...",
+                style: TextStyle(color: theme.getTheme().dividerColor)))
       ];
     } else {
-      var ts = TextStyle(color: textColor);
       var line = ((String s, String tt) => [
-            Tooltip(message: tt, child: Text(s, style: ts)),
+            Consumer<ThemeNotifier>(
+                builder: (context, theme, child) => Tooltip(
+                    message: tt,
+                    child: Text(s,
+                        style:
+                            TextStyle(color: theme.getTheme().dividerColor)))),
             const SizedBox(height: 10),
           ]);
       var copyable = ((String lbl, String txt, String tt) => [
             Tooltip(
                 message: tt,
-                child: Copyable("$lbl: $txt", ts, textToCopy: txt)),
+                child: Consumer<ThemeNotifier>(
+                    builder: (context, theme, child) => Copyable("$lbl: $txt",
+                        TextStyle(color: theme.getTheme().dividerColor),
+                        textToCopy: txt))),
             const SizedBox(height: 10),
           ]);
 
@@ -276,8 +283,12 @@ The receive balance is how much the local client may receive through LN payments
         const SizedBox(height: 10),
         ...(oerror != ""
             ? [
-                Copyable("Error: ${oerror}",
-                    TextStyle(color: errorColor, fontWeight: FontWeight.bold)),
+                Consumer<ThemeNotifier>(
+                    builder: (context, theme, child) => Copyable(
+                        "Error: ${oerror}",
+                        TextStyle(
+                            color: theme.getTheme().errorColor,
+                            fontWeight: FontWeight.bold))),
                 const SizedBox(height: 20)
               ]
             : []),
@@ -318,7 +329,8 @@ Cancelling onboarding means the wallet setup, including obtaining on-chain funds
         Consumer<ThemeNotifier>(
             builder: (context, theme, child) => Text("Recent Log",
                 style: TextStyle(
-                    color: textColor, fontSize: theme.getMediumFont(context)))),
+                    color: theme.getTheme().dividerColor,
+                    fontSize: theme.getMediumFont(context)))),
         Expanded(
             child: Consumer<LogModel>(
                 builder: (context, logModel, child) => LogLines(logModel))),
@@ -340,7 +352,7 @@ Cancelling onboarding means the wallet setup, including obtaining on-chain funds
       Consumer<ThemeNotifier>(
           builder: (context, theme, child) => Text("Setting up Bison Relay",
               style: TextStyle(
-                  color: textColor,
+                  color: theme.getTheme().dividerColor,
                   fontSize: theme.getHugeFont(context),
                   fontWeight: FontWeight.w200))),
       const SizedBox(height: 20),

--- a/bruig/flutterui/bruig/lib/screens/onboarding.dart
+++ b/bruig/flutterui/bruig/lib/screens/onboarding.dart
@@ -7,6 +7,7 @@ import 'package:bruig/components/recent_log.dart';
 import 'package:bruig/components/snackbars.dart';
 import 'package:bruig/models/log.dart';
 import 'package:bruig/models/notifications.dart';
+import 'package:bruig/screens/startupscreen.dart';
 import 'package:flutter/material.dart';
 import 'package:golib_plugin/definitions.dart';
 import 'package:golib_plugin/golib_plugin.dart';
@@ -324,53 +325,26 @@ Cancelling onboarding means the wallet setup, including obtaining on-chain funds
       ];
     }
 
-    return Scaffold(
-        body: Container(
-            color: backgroundColor,
-            child: Stack(children: [
-              Container(
-                  decoration: const BoxDecoration(
-                      image: DecorationImage(
-                          fit: BoxFit.fill,
-                          image: AssetImage("assets/images/loading-bg.png")))),
-              Container(
-                  decoration: BoxDecoration(
-                      gradient: LinearGradient(
-                          begin: Alignment.bottomLeft,
-                          end: Alignment.topRight,
-                          colors: [
-                        cardColor,
-                        const Color(0xFF07051C),
-                        backgroundColor.withOpacity(0.34),
-                      ],
-                          stops: const [
-                        0,
-                        0.17,
-                        1
-                      ])),
-                  padding: const EdgeInsets.all(10),
-                  child: Column(children: [
-                    Row(children: [
-                      IconButton(
-                          alignment: Alignment.topLeft,
-                          tooltip: "About Bison Relay",
-                          iconSize: 50,
-                          onPressed: goToAbout,
-                          icon: Image.asset(
-                            "assets/images/icon.png",
-                          )),
-                    ]),
-                    const SizedBox(height: 39),
-                    Consumer<ThemeNotifier>(
-                        builder: (context, theme, child) => Text(
-                            "Setting up Bison Relay",
-                            style: TextStyle(
-                                color: textColor,
-                                fontSize: theme.getHugeFont(context),
-                                fontWeight: FontWeight.w200))),
-                    const SizedBox(height: 20),
-                    ...children,
-                  ]))
-            ])));
+    return StartupScreen(Column(children: [
+      Row(children: [
+        IconButton(
+            alignment: Alignment.topLeft,
+            tooltip: "About Bison Relay",
+            iconSize: 50,
+            onPressed: goToAbout,
+            icon: Image.asset(
+              "assets/images/icon.png",
+            )),
+      ]),
+      const SizedBox(height: 39),
+      Consumer<ThemeNotifier>(
+          builder: (context, theme, child) => Text("Setting up Bison Relay",
+              style: TextStyle(
+                  color: textColor,
+                  fontSize: theme.getHugeFont(context),
+                  fontWeight: FontWeight.w200))),
+      const SizedBox(height: 20),
+      ...children,
+    ]));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/overview.dart
+++ b/bruig/flutterui/bruig/lib/screens/overview.dart
@@ -299,6 +299,7 @@ class _OverviewScreenState extends State<OverviewScreen> {
       backgroundColor: theme.canvasColor,
       appBar: isScreenSmall
           ? AppBar(
+              backgroundColor: sidebarBackground,
               leadingWidth: 60,
               titleSpacing: 0.0,
               title: _OverviewScreenTitle(widget.mainMenu),
@@ -368,6 +369,7 @@ class _OverviewScreenState extends State<OverviewScreen> {
                       : const Empty()
                 ])
           : AppBar(
+              backgroundColor: sidebarBackground,
               titleSpacing: 0.0,
               title: Row(children: [
                 _OverviewScreenTitle(widget.mainMenu),

--- a/bruig/flutterui/bruig/lib/screens/paystats.dart
+++ b/bruig/flutterui/bruig/lib/screens/paystats.dart
@@ -108,7 +108,7 @@ class _PayStatsScreenState extends State<PayStatsScreen> {
     var textColor = theme.focusColor;
     var backgroundColor = theme.backgroundColor;
     var otherBackgroundColor = theme.indicatorColor;
-    var otherTextColor = theme.dividerColor;
+    var otherTextColor = theme.highlightColor;
     var highlightColor = theme.highlightColor;
     return Consumer<ThemeNotifier>(
         builder: (context, theme, child) => Container(
@@ -170,6 +170,9 @@ class _PayStatsScreenState extends State<PayStatsScreen> {
                                               ? stats[index].item2
                                               : "User fees",
                                           style: TextStyle(
+                                              color: index.isOdd
+                                                  ? textColor
+                                                  : otherTextColor,
                                               fontSize: theme
                                                   .getSmallFont(context)))),
                                   SizedBox(
@@ -177,6 +180,9 @@ class _PayStatsScreenState extends State<PayStatsScreen> {
                                       child: Text(
                                           "${stats[index].item3.totalSent}",
                                           style: TextStyle(
+                                              color: index.isOdd
+                                                  ? textColor
+                                                  : otherTextColor,
                                               fontSize: theme
                                                   .getSmallFont(context)))),
                                   SizedBox(
@@ -184,6 +190,9 @@ class _PayStatsScreenState extends State<PayStatsScreen> {
                                       child: Text(
                                           "${stats[index].item3.totalReceived}",
                                           style: TextStyle(
+                                              color: index.isOdd
+                                                  ? textColor
+                                                  : otherTextColor,
                                               fontSize: theme
                                                   .getSmallFont(context)))),
                                   Expanded(

--- a/bruig/flutterui/bruig/lib/screens/settings.dart
+++ b/bruig/flutterui/bruig/lib/screens/settings.dart
@@ -518,6 +518,8 @@ class AccountSettingsScreen extends StatelessWidget {
 
 enum FontChoices { small, medium, large, xlarge }
 
+enum ThemeChoices { light, dark, system }
+
 class AppearanceSettingsScreen extends StatefulWidget {
   final ClientModel client;
   const AppearanceSettingsScreen(this.client, {Key? key}) : super(key: key);
@@ -530,6 +532,25 @@ class AppearanceSettingsScreen extends StatefulWidget {
 class _AppearanceSettingsScreenState extends State<AppearanceSettingsScreen> {
   ClientModel get client => widget.client;
   FontChoices _fontChoices = FontChoices.medium;
+  ThemeChoices _themeChoices = ThemeChoices.dark;
+
+  @override
+  void initState() {
+    Consumer<ThemeNotifier>(builder: (context, theme, _) {
+      ThemeChoices currentChoice = ThemeChoices.light;
+      if (theme.getThemeMode() == "dark") {
+        currentChoice = ThemeChoices.dark;
+      } else if (theme.getThemeMode() == "system") {
+        currentChoice = ThemeChoices.system;
+      }
+      setState(() {
+        _themeChoices = currentChoice;
+      });
+      return const Empty();
+    });
+
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -540,6 +561,77 @@ class _AppearanceSettingsScreenState extends State<AppearanceSettingsScreen> {
     return Consumer<ThemeNotifier>(
         builder: (context, theme, _) => ListView(
               children: [
+                ListTile(
+                    onTap: () => showDialog(
+                          context: context,
+                          builder: (BuildContext context) {
+                            return Dialog(
+                                shadowColor: backgroundColor,
+                                insetPadding: const EdgeInsets.symmetric(
+                                    horizontal: 40.0, vertical: 275.0),
+                                backgroundColor: backgroundColor,
+                                shape: const RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.all(
+                                        Radius.circular(16.0))),
+                                child: Container(
+                                    margin: const EdgeInsets.all(20),
+                                    child: Column(children: [
+                                      Row(children: [
+                                        Text("Theme",
+                                            style: TextStyle(
+                                                fontSize:
+                                                    theme.getLargeFont(context),
+                                                color: textColor)),
+                                      ]),
+                                      ListTile(
+                                          title: const Text('Light'),
+                                          leading: Radio<ThemeChoices>(
+                                            value: ThemeChoices.light,
+                                            groupValue: _themeChoices,
+                                            onChanged: (ThemeChoices? value) {
+                                              setState(() {
+                                                _themeChoices = value!;
+                                                theme.setLightMode();
+                                                Navigator.of(context).pop();
+                                              });
+                                            },
+                                          )),
+                                      ListTile(
+                                          title: const Text('Dark'),
+                                          leading: Radio<ThemeChoices>(
+                                            value: ThemeChoices.dark,
+                                            groupValue: _themeChoices,
+                                            onChanged: (ThemeChoices? value) {
+                                              setState(() {
+                                                _themeChoices = value!;
+                                                theme.setDarkMode();
+                                                Navigator.of(context).pop();
+                                              });
+                                            },
+                                          )),
+                                      ListTile(
+                                          title:
+                                              const Text('Use System Default'),
+                                          leading: Radio<ThemeChoices>(
+                                            value: ThemeChoices.system,
+                                            groupValue: _themeChoices,
+                                            onChanged: (ThemeChoices? value) {
+                                              setState(() {
+                                                _themeChoices = value!;
+                                                theme.setSystemMode();
+                                                Navigator.of(context).pop();
+                                              });
+                                            },
+                                          )),
+                                    ])));
+                          },
+                        ),
+                    hoverColor: backgroundColor,
+                    leading: const Icon(Icons.person_outline),
+                    title: Text("Theme",
+                        style: TextStyle(
+                            fontSize: theme.getMediumFont(context),
+                            color: textColor))),
                 ListTile(
                     onTap: () => showDialog(
                           context: context,

--- a/bruig/flutterui/bruig/lib/screens/settings.dart
+++ b/bruig/flutterui/bruig/lib/screens/settings.dart
@@ -198,7 +198,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
             borderRadius: BorderRadius.circular(3), color: backgroundColor),
         padding: const EdgeInsets.all(10),
         child: Column(children: [
-          /*
           // XXX HIDING THEME BUTTON UNTIL LIGHT THEME PROVIDED
           ElevatedButton(
             onPressed: () => {
@@ -210,7 +209,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 ? Text('Set Light Theme')
                 : Text('Set Dark Theme'),
           ),
-          */
           Tooltip(
               message: "User avatar. Click to select a new image.",
               child: InkWell(

--- a/bruig/flutterui/bruig/lib/screens/shutdown.dart
+++ b/bruig/flutterui/bruig/lib/screens/shutdown.dart
@@ -67,53 +67,21 @@ class _ShutdownScreenState extends State<ShutdownScreen> {
 
   @override
   Widget build(BuildContext context) {
-    var backgroundColor = const Color(0xFF19172C);
-    var cardColor = const Color(0xFF05031A);
-    var textColor = const Color(0xFF8E8D98);
     return Consumer<ThemeNotifier>(
-        builder: (context, theme, child) => Scaffold(
-            body: Container(
-                color: backgroundColor,
-                child: Stack(children: [
-                  Container(
-                      decoration: const BoxDecoration(
-                          image: DecorationImage(
-                              fit: BoxFit.fill,
-                              image:
-                                  AssetImage("assets/images/loading-bg.png")))),
-                  Container(
-                    decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                            begin: Alignment.bottomLeft,
-                            end: Alignment.topRight,
-                            colors: [
-                          cardColor,
-                          const Color(0xFF07051C),
-                          backgroundColor.withOpacity(0.34),
-                        ],
-                            stops: const [
-                          0,
-                          0.17,
-                          1
-                        ])),
-                  ),
-                  Container(
-                      padding: const EdgeInsets.all(10),
-                      child: Column(children: [
-                        const SizedBox(height: 89),
-                        Text("Shutting Down Bison Relay",
-                            style: TextStyle(
-                                color: textColor,
-                                fontSize: theme.getHugeFont(context),
-                                fontWeight: FontWeight.w200)),
-                        clientStopErr != null
-                            ? Text(clientStopErr!)
-                            : const Empty(),
-                        const SizedBox(height: 20),
-                        const Divider(),
-                        const SizedBox(height: 20),
-                        Expanded(child: LogLines(widget.log))
-                      ]))
-                ]))));
+        builder: (context, theme, child) => Container(
+            padding: const EdgeInsets.all(10),
+            child: Column(children: [
+              const SizedBox(height: 89),
+              Text("Shutting Down Bison Relay",
+                  style: TextStyle(
+                      color: theme.getTheme().dividerColor,
+                      fontSize: theme.getHugeFont(context),
+                      fontWeight: FontWeight.w200)),
+              clientStopErr != null ? Text(clientStopErr!) : const Empty(),
+              const SizedBox(height: 20),
+              const Divider(),
+              const SizedBox(height: 20),
+              Expanded(child: LogLines(widget.log))
+            ])));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/startupscreen.dart
+++ b/bruig/flutterui/bruig/lib/screens/startupscreen.dart
@@ -10,8 +10,6 @@ class StartupScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     print("is child null? ${child != null}");
     bool isScreenSmall = MediaQuery.of(context).size.width <= 500;
-    var wideBG = const DecorationImage(
-        fit: BoxFit.fill, image: AssetImage("assets/images/loading-bg.png"));
     var mobileBG = const DecorationImage(
         fit: BoxFit.fill, image: AssetImage("assets/images/testBG.gif"));
     return Consumer<ThemeNotifier>(
@@ -19,8 +17,19 @@ class StartupScreen extends StatelessWidget {
             color: theme.getTheme().backgroundColor,
             child: Stack(children: [
               Container(
-                  decoration:
-                      BoxDecoration(image: isScreenSmall ? mobileBG : wideBG)),
+                  decoration: BoxDecoration(
+                      image: isScreenSmall
+                          ? theme.getTheme().brightness == Brightness.light
+                              ? null
+                              : mobileBG
+                          : DecorationImage(
+                              fit: BoxFit.fill,
+                              image: const AssetImage(
+                                  "assets/images/loading-bg.png"),
+                              opacity: theme.getTheme().brightness ==
+                                      Brightness.light
+                                  ? 0.25
+                                  : 1))),
               Container(
                   decoration: isScreenSmall
                       ? null

--- a/bruig/flutterui/bruig/lib/screens/startupscreen.dart
+++ b/bruig/flutterui/bruig/lib/screens/startupscreen.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:bruig/theme_manager.dart';
+
+class StartupScreen extends StatelessWidget {
+  final Widget? child;
+  const StartupScreen(this.child, {Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    print("is child null? ${child != null}");
+    bool isScreenSmall = MediaQuery.of(context).size.width <= 500;
+    var wideBG = const DecorationImage(
+        fit: BoxFit.fill, image: AssetImage("assets/images/loading-bg.png"));
+    var mobileBG = const DecorationImage(
+        fit: BoxFit.fill, image: AssetImage("assets/images/testBG.gif"));
+    return Consumer<ThemeNotifier>(
+        builder: (context, theme, child) => Container(
+            color: theme.getTheme().backgroundColor,
+            child: Stack(children: [
+              Container(
+                  decoration:
+                      BoxDecoration(image: isScreenSmall ? mobileBG : wideBG)),
+              Container(
+                  decoration: isScreenSmall
+                      ? null
+                      : BoxDecoration(
+                          gradient: LinearGradient(
+                              begin: Alignment.bottomLeft,
+                              end: Alignment.topRight,
+                              colors: [
+                              theme.getTheme().canvasColor,
+                              theme.getTheme().backgroundColor,
+                              theme.getTheme().canvasColor.withOpacity(0.34),
+                            ],
+                              stops: const [
+                              0,
+                              0.17,
+                              1
+                            ])),
+                  padding: const EdgeInsets.all(30),
+                  child: this.child)
+            ])));
+  }
+}

--- a/bruig/flutterui/bruig/lib/screens/unlock_ln.dart
+++ b/bruig/flutterui/bruig/lib/screens/unlock_ln.dart
@@ -348,10 +348,8 @@ class _LNChainSyncPageState extends State<_LNChainSyncPage> {
       Navigator.of(context).pushNamed("/about");
     }
 
-    return Consumer<ThemeNotifier>(
-        builder: (context, theme, child) => Container(
-            padding: const EdgeInsets.all(10),
-            child: Column(children: [
+    return StartupScreen(Consumer<ThemeNotifier>(
+        builder: (context, theme, child) => Column(children: [
               Row(children: [
                 IconButton(
                     alignment: Alignment.topLeft,
@@ -471,7 +469,6 @@ class _LNChainSyncPageState extends State<_LNChainSyncPage> {
                     ])),
               )
             ])));
-    ;
   }
 }
 

--- a/bruig/flutterui/bruig/lib/screens/unlock_ln.dart
+++ b/bruig/flutterui/bruig/lib/screens/unlock_ln.dart
@@ -7,6 +7,7 @@ import 'package:bruig/screens/about.dart';
 import 'package:bruig/config.dart';
 import 'package:bruig/main.dart';
 import 'package:bruig/models/log.dart';
+import 'package:bruig/screens/startupscreen.dart';
 import 'package:flutter/material.dart';
 import 'package:golib_plugin/golib_plugin.dart';
 import 'package:path/path.dart' as path;
@@ -105,225 +106,185 @@ class __LNUnlockPageState extends State<_LNUnlockPage> {
 
   @override
   Widget build(BuildContext context) {
-    var backgroundColor = const Color(0xFF19172C);
-    var cardColor = const Color(0xFF05031A);
-    var textColor = const Color(0xFF8E8D98);
-    var secondaryTextColor = const Color(0xFFE4E3E6);
-    var darkTextColor = const Color(0xFF5A5968);
     bool isScreenSmall = MediaQuery.of(context).size.width <= 500;
-    var wideBG = const DecorationImage(
-        fit: BoxFit.fill, image: AssetImage("assets/images/loading-bg.png"));
-    var mobileBG = const DecorationImage(
-        fit: BoxFit.fill, image: AssetImage("assets/images/testBG.gif"));
-    return Consumer<ThemeNotifier>(
-        builder: (context, theme, child) => Container(
-            color: backgroundColor,
-            child: Stack(children: [
-              Container(
-                  decoration:
-                      BoxDecoration(image: isScreenSmall ? mobileBG : wideBG)),
-              Container(
-                decoration: isScreenSmall
-                    ? null
-                    : BoxDecoration(
-                        gradient: LinearGradient(
-                            begin: Alignment.bottomLeft,
-                            end: Alignment.topRight,
-                            colors: [
-                            cardColor,
-                            const Color(0xFF07051C),
-                            backgroundColor.withOpacity(0.34),
-                          ],
-                            stops: const [
-                            0,
-                            0.17,
-                            1
-                          ])),
-                padding: const EdgeInsets.all(30),
-                child: isScreenSmall
-                    ? Column(
-                        mainAxisAlignment: MainAxisAlignment.end,
-                        children: [
-                            SizedBox(
-                                height: MediaQuery.of(context).size.height / 9),
-                            SizedBox(
-                                width: 250,
-                                child: Text("Connect to Bison Relay",
-                                    textAlign: TextAlign.center,
-                                    style: TextStyle(
-                                        color: secondaryTextColor,
-                                        fontSize: theme.getHugeFont(context),
-                                        fontWeight: FontWeight.w300))),
-                            const SizedBox(height: 50),
-                            loading
-                                ? SizedBox(
-                                    width: 50,
-                                    height: 50,
-                                    child: CircularProgressIndicator(
-                                        value: null,
-                                        backgroundColor: backgroundColor,
-                                        color: secondaryTextColor,
-                                        strokeWidth: 2),
-                                  )
-                                : const SizedBox(height: 50),
-                            const SizedBox(height: 20),
-                            Expanded(
-                                child: TextField(
-                                    enabled: !loading,
-                                    autofocus: true,
-                                    cursorColor: secondaryTextColor,
-                                    decoration: InputDecoration(
-                                        enabled: !loading,
-                                        labelText: "Password",
-                                        labelStyle: TextStyle(
-                                            letterSpacing: 0,
-                                            color: secondaryTextColor),
-                                        errorText:
-                                            _validate != "" ? _validate : null,
-                                        errorBorder: const OutlineInputBorder(
-                                          borderRadius: BorderRadius.all(
-                                              Radius.circular(10.0)),
-                                          borderSide: BorderSide(
-                                              color: Colors.red, width: 2.0),
-                                        ),
-                                        focusedBorder: OutlineInputBorder(
-                                          borderRadius: const BorderRadius.all(
-                                              Radius.circular(10.0)),
-                                          borderSide: BorderSide(
-                                              color: secondaryTextColor,
-                                              width: 2.0),
-                                        ),
-                                        border: OutlineInputBorder(
-                                          borderRadius: const BorderRadius.all(
-                                              Radius.circular(10.0)),
-                                          borderSide: BorderSide(
-                                              color: cardColor, width: 2.0),
-                                        ),
-                                        hintText: "Password",
-                                        hintStyle: TextStyle(
-                                            letterSpacing: 0,
-                                            fontWeight: FontWeight.w100,
-                                            color: secondaryTextColor),
-                                        filled: true,
-                                        fillColor: cardColor),
-                                    style: TextStyle(
-                                        letterSpacing: 5,
-                                        color: secondaryTextColor,
-                                        fontSize: theme.getLargeFont(context)),
-                                    controller: passCtrl,
-                                    obscureText: true,
-                                    onSubmitted: (value) {
-                                      if (!loading) {
-                                        unlock();
-                                      }
-                                    },
-                                    onChanged: (value) {
-                                      setState(() {
-                                        _validate = value.isEmpty
-                                            ? "Password cannot be empty"
-                                            : "";
-                                      });
-                                    })),
-                            _validate == ""
-                                ? const SizedBox(height: 22)
-                                : const Empty(),
-                            const SizedBox(height: 34),
+    return StartupScreen(Consumer<ThemeNotifier>(
+      builder: (context, theme, _) {
+        return isScreenSmall
+            ? Column(mainAxisAlignment: MainAxisAlignment.end, children: [
+                SizedBox(height: MediaQuery.of(context).size.height / 9),
+                SizedBox(
+                    width: 250,
+                    child: Text("Connect to Bison Relay",
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                            color: theme.getTheme().indicatorColor,
+                            fontSize: theme.getHugeFont(context),
+                            fontWeight: FontWeight.w300))),
+                const SizedBox(height: 50),
+                loading
+                    ? SizedBox(
+                        width: 50,
+                        height: 50,
+                        child: CircularProgressIndicator(
+                            value: null,
+                            backgroundColor: theme.getTheme().backgroundColor,
+                            color: theme.getTheme().indicatorColor,
+                            strokeWidth: 2),
+                      )
+                    : const SizedBox(height: 50),
+                const SizedBox(height: 20),
+                Expanded(
+                    child: TextField(
+                        enabled: !loading,
+                        autofocus: true,
+                        cursorColor: theme.getTheme().indicatorColor,
+                        decoration: InputDecoration(
+                            enabled: !loading,
+                            labelText: "Password",
+                            labelStyle: TextStyle(
+                                letterSpacing: 0,
+                                color: theme.getTheme().indicatorColor),
+                            errorText: _validate != "" ? _validate : null,
+                            errorBorder: const OutlineInputBorder(
+                              borderRadius:
+                                  BorderRadius.all(Radius.circular(10.0)),
+                              borderSide:
+                                  BorderSide(color: Colors.red, width: 2.0),
+                            ),
+                            focusedBorder: OutlineInputBorder(
+                              borderRadius:
+                                  const BorderRadius.all(Radius.circular(10.0)),
+                              borderSide: BorderSide(
+                                  color: theme.getTheme().indicatorColor,
+                                  width: 2.0),
+                            ),
+                            border: OutlineInputBorder(
+                              borderRadius:
+                                  const BorderRadius.all(Radius.circular(10.0)),
+                              borderSide: BorderSide(
+                                  color: theme.getTheme().cardColor,
+                                  width: 2.0),
+                            ),
+                            hintText: "Password",
+                            hintStyle: TextStyle(
+                                letterSpacing: 0,
+                                fontWeight: FontWeight.w100,
+                                color: theme.getTheme().indicatorColor),
+                            filled: true,
+                            fillColor: theme.getTheme().cardColor),
+                        style: TextStyle(
+                            letterSpacing: 5,
+                            color: theme.getTheme().indicatorColor,
+                            fontSize: theme.getLargeFont(context)),
+                        controller: passCtrl,
+                        obscureText: true,
+                        onSubmitted: (value) {
+                          if (!loading) {
+                            unlock();
+                          }
+                        },
+                        onChanged: (value) {
+                          setState(() {
+                            _validate =
+                                value.isEmpty ? "Password cannot be empty" : "";
+                          });
+                        })),
+                _validate == "" ? const SizedBox(height: 22) : const Empty(),
+                const SizedBox(height: 34),
+                LoadingScreenButton(
+                  minSize: MediaQuery.of(context).size.width,
+                  onPressed: !loading ? unlock : null,
+                  text: "Unlock Wallet",
+                ),
+              ])
+            : Column(children: [
+                Row(children: [
+                  IconButton(
+                      alignment: Alignment.topLeft,
+                      tooltip: "About Bison Relay",
+                      iconSize: 50,
+                      onPressed: goToAbout,
+                      icon: Image.asset(
+                        "assets/images/icon.png",
+                      )),
+                ]),
+                const SizedBox(height: 208),
+                Text("Connect to Bison Relay",
+                    style: TextStyle(
+                        color: theme.getTheme().dividerColor,
+                        fontSize: theme.getHugeFont(context),
+                        fontWeight: FontWeight.w200)),
+                const SizedBox(height: 34),
+                Column(children: [
+                  SizedBox(
+                      width: 377,
+                      child: Text("Password",
+                          textAlign: TextAlign.left,
+                          style: TextStyle(
+                              color: theme.getTheme().indicatorColor,
+                              fontSize: theme.getMediumFont(context),
+                              fontWeight: FontWeight.w300))),
+                  const SizedBox(height: 5),
+                  Center(
+                      child: SizedBox(
+                          width: 377,
+                          child: TextField(
+                              autofocus: true,
+                              cursorColor: theme.getTheme().indicatorColor,
+                              decoration: InputDecoration(
+                                  errorText: _validate,
+                                  border: InputBorder.none,
+                                  hintText: "Password",
+                                  hintStyle: TextStyle(
+                                      fontSize: theme.getLargeFont(context),
+                                      color: theme.getTheme().dividerColor),
+                                  filled: true,
+                                  fillColor: theme.getTheme().cardColor),
+                              style: TextStyle(
+                                  color: theme.getTheme().indicatorColor,
+                                  fontSize: theme.getLargeFont(context)),
+                              controller: passCtrl,
+                              obscureText: true,
+                              onSubmitted: (value) {
+                                if (!loading) {
+                                  unlock();
+                                }
+                              },
+                              onChanged: (value) {
+                                setState(() {
+                                  _validate = value.isEmpty
+                                      ? "Password cannot be empty"
+                                      : "";
+                                });
+                              }))),
+                  const SizedBox(height: 34),
+                  Center(
+                      child: SizedBox(
+                          width: 283,
+                          child: Row(children: [
+                            const SizedBox(width: 35),
                             LoadingScreenButton(
-                              minSize: MediaQuery.of(context).size.width,
                               onPressed: !loading ? unlock : null,
                               text: "Unlock Wallet",
                             ),
-                          ])
-                    : Column(children: [
-                        Row(children: [
-                          IconButton(
-                              alignment: Alignment.topLeft,
-                              tooltip: "About Bison Relay",
-                              iconSize: 50,
-                              onPressed: goToAbout,
-                              icon: Image.asset(
-                                "assets/images/icon.png",
-                              )),
-                        ]),
-                        const SizedBox(height: 208),
-                        Text("Connect to Bison Relay",
-                            style: TextStyle(
-                                color: textColor,
-                                fontSize: theme.getHugeFont(context),
-                                fontWeight: FontWeight.w200)),
-                        const SizedBox(height: 34),
-                        Column(children: [
-                          SizedBox(
-                              width: 377,
-                              child: Text("Password",
-                                  textAlign: TextAlign.left,
-                                  style: TextStyle(
-                                      color: darkTextColor,
-                                      fontSize: theme.getMediumFont(context),
-                                      fontWeight: FontWeight.w300))),
-                          const SizedBox(height: 5),
-                          Center(
-                              child: SizedBox(
-                                  width: 377,
-                                  child: TextField(
-                                      autofocus: true,
-                                      cursorColor: secondaryTextColor,
-                                      decoration: InputDecoration(
-                                          errorText: _validate,
-                                          border: InputBorder.none,
-                                          hintText: "Password",
-                                          hintStyle: TextStyle(
-                                              fontSize:
-                                                  theme.getLargeFont(context),
-                                              color: textColor),
-                                          filled: true,
-                                          fillColor: cardColor),
-                                      style: TextStyle(
-                                          color: secondaryTextColor,
-                                          fontSize:
-                                              theme.getLargeFont(context)),
-                                      controller: passCtrl,
-                                      obscureText: true,
-                                      onSubmitted: (value) {
-                                        if (!loading) {
-                                          unlock();
-                                        }
-                                      },
-                                      onChanged: (value) {
-                                        setState(() {
-                                          _validate = value.isEmpty
-                                              ? "Password cannot be empty"
-                                              : "";
-                                        });
-                                      }))),
-                          const SizedBox(height: 34),
-                          Center(
-                              child: SizedBox(
-                                  width: 283,
-                                  child: Row(children: [
-                                    const SizedBox(width: 35),
-                                    LoadingScreenButton(
-                                      onPressed: !loading ? unlock : null,
-                                      text: "Unlock Wallet",
-                                    ),
-                                    const SizedBox(width: 10),
-                                    loading
-                                        ? SizedBox(
-                                            height: 25,
-                                            width: 25,
-                                            child: CircularProgressIndicator(
-                                                value: null,
-                                                backgroundColor:
-                                                    backgroundColor,
-                                                color: textColor,
-                                                strokeWidth: 2),
-                                          )
-                                        : const SizedBox(width: 25),
-                                  ])))
-                        ]),
-                      ]),
-              )
-            ])));
+                            const SizedBox(width: 10),
+                            loading
+                                ? SizedBox(
+                                    height: 25,
+                                    width: 25,
+                                    child: CircularProgressIndicator(
+                                        value: null,
+                                        backgroundColor:
+                                            theme.getTheme().backgroundColor,
+                                        color: theme.getTheme().dividerColor,
+                                        strokeWidth: 2),
+                                  )
+                                : const SizedBox(width: 25),
+                          ])))
+                ]),
+              ]);
+      },
+    ));
   }
 }
 
@@ -382,174 +343,135 @@ class _LNChainSyncPageState extends State<_LNChainSyncPage> {
 
   @override
   Widget build(BuildContext context) {
-    var backgroundColor = const Color(0xFF19172C);
-    var cardColor = const Color(0xFF05031A);
-    var textColor = const Color(0xFF8E8D98);
-    var secondaryTextColor = const Color(0xFFE4E3E6);
     bool isScreenSmall = MediaQuery.of(context).size.width <= 500;
-    var wideBG = const DecorationImage(
-        fit: BoxFit.fill, image: AssetImage("assets/images/loading-bg.png"));
-    var mobileBG = const DecorationImage(
-        fit: BoxFit.fill, image: AssetImage("assets/images/testBG.gif"));
     void goToAbout() {
       Navigator.of(context).pushNamed("/about");
     }
 
     return Consumer<ThemeNotifier>(
         builder: (context, theme, child) => Container(
-            color: backgroundColor,
-            child: Stack(children: [
-              Container(
-                  decoration:
-                      BoxDecoration(image: isScreenSmall ? mobileBG : wideBG)),
-              isScreenSmall
-                  ? const Empty()
-                  : Container(
-                      decoration: BoxDecoration(
-                          gradient: LinearGradient(
-                              begin: Alignment.bottomLeft,
-                              end: Alignment.topRight,
-                              colors: [
-                            cardColor,
-                            const Color(0xFF07051C),
-                            backgroundColor.withOpacity(0.34),
-                          ],
-                              stops: const [
-                            0,
-                            0.17,
-                            1
-                          ])),
-                    ),
-              Container(
-                  padding: const EdgeInsets.all(10),
-                  child: Column(children: [
-                    Row(children: [
-                      IconButton(
-                          alignment: Alignment.topLeft,
-                          tooltip: "About Bison Relay",
-                          iconSize: 50,
-                          onPressed: goToAbout,
-                          icon: Image.asset(
-                            "assets/images/icon.png",
-                          )),
-                    ]),
-                    const SizedBox(height: 39),
-                    Text("Setting up Bison Relay",
-                        style: TextStyle(
-                            color: textColor,
-                            fontSize: theme.getHugeFont(context),
-                            fontWeight: FontWeight.w200)),
-                    const SizedBox(height: 89),
-                    Text("Network Sync",
-                        style: TextStyle(
-                            color: secondaryTextColor,
-                            fontSize: theme.getLargeFont(context),
-                            fontWeight: FontWeight.w300)),
-                    const SizedBox(height: 50),
-                    Center(
-                        child: SizedBox(
-                            width: 740,
-                            child: Row(children: [
-                              const SizedBox(width: 65),
-                              Expanded(
-                                  child: ClipRRect(
-                                      borderRadius: const BorderRadius.all(
-                                          Radius.circular(5)),
-                                      child: LinearProgressIndicator(
-                                          minHeight: 8,
-                                          value: progress > 1 ? 1 : progress,
-                                          color: cardColor,
-                                          backgroundColor: cardColor,
-                                          valueColor:
-                                              AlwaysStoppedAnimation<Color>(
-                                                  textColor)))),
-                              const SizedBox(width: 20),
-                              Text(
-                                  "${((progress > 1 ? 1 : progress) * 100).toStringAsFixed(0)}%",
+            padding: const EdgeInsets.all(10),
+            child: Column(children: [
+              Row(children: [
+                IconButton(
+                    alignment: Alignment.topLeft,
+                    tooltip: "About Bison Relay",
+                    iconSize: 50,
+                    onPressed: goToAbout,
+                    icon: Image.asset(
+                      "assets/images/icon.png",
+                    )),
+              ]),
+              const SizedBox(height: 39),
+              Text("Setting up Bison Relay",
+                  style: TextStyle(
+                      color: theme.getTheme().dividerColor,
+                      fontSize: theme.getHugeFont(context),
+                      fontWeight: FontWeight.w200)),
+              const SizedBox(height: 89),
+              Text("Network Sync",
+                  style: TextStyle(
+                      color: theme.getTheme().focusColor,
+                      fontSize: theme.getLargeFont(context),
+                      fontWeight: FontWeight.w300)),
+              const SizedBox(height: 50),
+              Center(
+                  child: SizedBox(
+                      width: 740,
+                      child: Row(children: [
+                        const SizedBox(width: 65),
+                        Expanded(
+                            child: ClipRRect(
+                                borderRadius:
+                                    const BorderRadius.all(Radius.circular(5)),
+                                child: LinearProgressIndicator(
+                                    minHeight: 8,
+                                    value: progress > 1 ? 1 : progress,
+                                    color: theme.getTheme().cardColor,
+                                    backgroundColor: theme.getTheme().cardColor,
+                                    valueColor: AlwaysStoppedAnimation<Color>(
+                                        theme.getTheme().dividerColor)))),
+                        const SizedBox(width: 20),
+                        Text(
+                            "${((progress > 1 ? 1 : progress) * 100).toStringAsFixed(0)}%",
+                            style: TextStyle(
+                                color: theme.getTheme().dividerColor,
+                                fontSize: theme.getMediumFont(context),
+                                fontWeight: FontWeight.w300))
+                      ]))),
+              const SizedBox(height: 21),
+              Center(
+                child: Container(
+                    margin: const EdgeInsets.all(0),
+                    width: 610,
+                    height: 251,
+                    padding: const EdgeInsets.all(10),
+                    color: theme.getTheme().cardColor,
+                    child: Column(children: [
+                      Flex(
+                          direction:
+                              isScreenSmall ? Axis.vertical : Axis.horizontal,
+                          children: [
+                            RichText(
+                                text: TextSpan(children: [
+                              TextSpan(
+                                  text: "Block Height: ",
                                   style: TextStyle(
-                                      color: textColor,
-                                      fontSize: theme.getMediumFont(context),
+                                      color: theme.getTheme().dividerColor,
+                                      fontSize: theme.getSmallFont(context),
+                                      fontWeight: FontWeight.w300)),
+                              TextSpan(
+                                  text: "$blockHeight",
+                                  style: TextStyle(
+                                      color: theme.getTheme().dividerColor,
+                                      fontSize: theme.getSmallFont(context),
                                       fontWeight: FontWeight.w300))
-                            ]))),
-                    const SizedBox(height: 21),
-                    Center(
-                      child: Container(
-                          margin: const EdgeInsets.all(0),
-                          width: 610,
-                          height: 251,
-                          padding: const EdgeInsets.all(10),
-                          color: cardColor,
-                          child: Column(children: [
-                            Flex(
-                                direction: isScreenSmall
-                                    ? Axis.vertical
-                                    : Axis.horizontal,
-                                children: [
-                                  RichText(
-                                      text: TextSpan(children: [
-                                    TextSpan(
-                                        text: "Block Height: ",
-                                        style: TextStyle(
-                                            color: textColor,
-                                            fontSize:
-                                                theme.getSmallFont(context),
-                                            fontWeight: FontWeight.w300)),
-                                    TextSpan(
-                                        text: "$blockHeight",
-                                        style: TextStyle(
-                                            color: textColor,
-                                            fontSize:
-                                                theme.getSmallFont(context),
-                                            fontWeight: FontWeight.w300))
-                                  ])),
-                                  isScreenSmall
-                                      ? const SizedBox(height: 5)
-                                      : const SizedBox(width: 21),
-                                  RichText(
-                                      text: TextSpan(children: [
-                                    TextSpan(
-                                        text: "Block Hash: ",
-                                        style: TextStyle(
-                                            color: textColor,
-                                            fontSize:
-                                                theme.getSmallFont(context),
-                                            fontWeight: FontWeight.w300)),
-                                    TextSpan(
-                                        text: "$blockHeight",
-                                        style: TextStyle(
-                                            color: textColor,
-                                            fontSize:
-                                                theme.getSmallFont(context),
-                                            fontWeight: FontWeight.w300))
-                                  ])),
-                                  isScreenSmall
-                                      ? const SizedBox(height: 5)
-                                      : const SizedBox(width: 21),
-                                  RichText(
-                                      text: TextSpan(children: [
-                                    TextSpan(
-                                        text: "Block Time: ",
-                                        style: TextStyle(
-                                            color: textColor,
-                                            fontSize:
-                                                theme.getSmallFont(context),
-                                            fontWeight: FontWeight.w300)),
-                                    TextSpan(
-                                        text: blockTimestamp.toString(),
-                                        style: TextStyle(
-                                            color: textColor,
-                                            fontSize:
-                                                theme.getSmallFont(context),
-                                            fontWeight: FontWeight.w300))
-                                  ]))
-                                ]),
-                            Expanded(
-                                child: LogLines(globalLogModel,
-                                    maxLines: 15, optionalTextColor: textColor))
-                          ])),
-                    )
-                  ]))
+                            ])),
+                            isScreenSmall
+                                ? const SizedBox(height: 5)
+                                : const SizedBox(width: 21),
+                            RichText(
+                                text: TextSpan(children: [
+                              TextSpan(
+                                  text: "Block Hash: ",
+                                  style: TextStyle(
+                                      color: theme.getTheme().dividerColor,
+                                      fontSize: theme.getSmallFont(context),
+                                      fontWeight: FontWeight.w300)),
+                              TextSpan(
+                                  text: "$blockHeight",
+                                  style: TextStyle(
+                                      color: theme.getTheme().dividerColor,
+                                      fontSize: theme.getSmallFont(context),
+                                      fontWeight: FontWeight.w300))
+                            ])),
+                            isScreenSmall
+                                ? const SizedBox(height: 5)
+                                : const SizedBox(width: 21),
+                            RichText(
+                                text: TextSpan(children: [
+                              TextSpan(
+                                  text: "Block Time: ",
+                                  style: TextStyle(
+                                      color: theme.getTheme().dividerColor,
+                                      fontSize: theme.getSmallFont(context),
+                                      fontWeight: FontWeight.w300)),
+                              TextSpan(
+                                  text: blockTimestamp.toString(),
+                                  style: TextStyle(
+                                      color: theme.getTheme().dividerColor,
+                                      fontSize: theme.getSmallFont(context),
+                                      fontWeight: FontWeight.w300))
+                            ]))
+                          ]),
+                      Expanded(
+                          child: LogLines(globalLogModel,
+                              maxLines: 15,
+                              optionalTextColor: theme.getTheme().dividerColor))
+                    ])),
+              )
             ])));
+    ;
   }
 }
 

--- a/bruig/flutterui/bruig/lib/screens/verify_invite.dart
+++ b/bruig/flutterui/bruig/lib/screens/verify_invite.dart
@@ -56,34 +56,41 @@ class _VerifyInviteScreenState extends State<VerifyInviteScreen> {
   }
 
   Widget buildFundsWidget(BuildContext context, InviteFunds funds) {
-    var textColor = const Color(0xFF8E8D98);
-    var ts = TextStyle(color: textColor);
-
     if (redeemed != null) {
       var total = formatDCR(atomsToDCR(redeemed!.total));
-      return Column(children: [
-        Text("Redeemed $total on the following tx:", style: ts),
-        Copyable(redeemed!.txid, ts),
-        Text("The funds will be available after the tx is mined.", style: ts),
-      ]);
+      return StartupScreen(Consumer<ThemeNotifier>(
+          builder: (context, theme, child) => Column(children: [
+                Text("Redeemed $total on the following tx:",
+                    style: TextStyle(color: theme.getTheme().dividerColor)),
+                Copyable(redeemed!.txid,
+                    TextStyle(color: theme.getTheme().dividerColor)),
+                Text("The funds will be available after the tx is mined.",
+                    style: TextStyle(color: theme.getTheme().dividerColor)),
+              ])));
     }
 
     if (redeeming) {
-      return Text("Attempting to redeem funds...", style: ts);
+      return StartupScreen(Consumer<ThemeNotifier>(
+          builder: (context, theme, child) => Text(
+              "Attempting to redeem funds...",
+              style: TextStyle(color: theme.getTheme().dividerColor))));
     }
 
-    return Column(children: [
-      Column(children: [
-        Text("This invite contains funds stored in the following UTXO:",
-            style: ts),
-        Copyable("${funds.txid}:${funds.index}", ts),
-        Text("Attempt to redeem funds?", style: ts),
-      ]),
-      const SizedBox(height: 10),
-      ElevatedButton(
-          onPressed: () => redeemFunds(context, funds),
-          child: const Text("Redeem Funds")),
-    ]);
+    return StartupScreen(Consumer<ThemeNotifier>(
+        builder: (context, theme, child) => Column(children: [
+              Column(children: [
+                Text("This invite contains funds stored in the following UTXO:",
+                    style: TextStyle(color: theme.getTheme().dividerColor)),
+                Copyable("${funds.txid}:${funds.index}",
+                    TextStyle(color: theme.getTheme().dividerColor)),
+                Text("Attempt to redeem funds?",
+                    style: TextStyle(color: theme.getTheme().dividerColor)),
+              ]),
+              const SizedBox(height: 10),
+              ElevatedButton(
+                  onPressed: () => redeemFunds(context, funds),
+                  child: const Text("Redeem Funds")),
+            ])));
   }
 
   @override

--- a/bruig/flutterui/bruig/lib/screens/verify_invite.dart
+++ b/bruig/flutterui/bruig/lib/screens/verify_invite.dart
@@ -8,6 +8,7 @@ import 'package:golib_plugin/golib_plugin.dart';
 import 'package:golib_plugin/util.dart';
 import 'package:provider/provider.dart';
 import 'package:bruig/theme_manager.dart';
+import 'package:bruig/screens/startupscreen.dart';
 
 class VerifyInviteScreen extends StatefulWidget {
   const VerifyInviteScreen({Key? key}) : super(key: key);
@@ -89,78 +90,46 @@ class _VerifyInviteScreenState extends State<VerifyInviteScreen> {
   Widget build(BuildContext context) {
     var invite = ModalRoute.of(context)!.settings.arguments as Invitation;
 
-    var backgroundColor = const Color(0xFF19172C);
-    var cardColor = const Color(0xFF05031A);
-    var textColor = const Color(0xFF8E8D98);
     var errorColor = Colors.red;
-    return Consumer<ThemeNotifier>(
-        builder: (context, theme, child) => Scaffold(
-            body: Container(
-                color: backgroundColor,
-                child: Stack(children: [
-                  Container(
-                      decoration: const BoxDecoration(
-                          image: DecorationImage(
-                              fit: BoxFit.fill,
-                              image:
-                                  AssetImage("assets/images/loading-bg.png")))),
-                  Container(
-                      decoration: BoxDecoration(
-                          gradient: LinearGradient(
-                              begin: Alignment.bottomLeft,
-                              end: Alignment.topRight,
-                              colors: [
-                            cardColor,
-                            const Color(0xFF07051C),
-                            backgroundColor.withOpacity(0.34),
-                          ],
-                              stops: const [
-                            0,
-                            0.17,
-                            1
-                          ])),
-                      padding: const EdgeInsets.all(10),
-                      child: Column(children: [
-                        const Expanded(child: Empty()),
-                        Text("Accept Invite",
-                            style: TextStyle(
-                                color: textColor,
-                                fontSize: theme.getHugeFont(context),
-                                fontWeight: FontWeight.w200)),
-                        const SizedBox(height: 34),
-                        invite.invite.funds != null
-                            ? buildFundsWidget(context, invite.invite.funds!)
-                            : const Empty(),
-                        const SizedBox(height: 20),
-                        Text("Name: ${invite.invite.public.name}",
-                            style: TextStyle(
-                                color: textColor,
-                                fontSize: theme.getMediumFont(context),
-                                fontWeight: FontWeight.w300)),
-                        Text("Nick: ${invite.invite.public.nick}",
-                            style: TextStyle(
-                                color: textColor,
-                                fontSize: theme.getMediumFont(context),
-                                fontWeight: FontWeight.w300)),
-                        Text("Identity: ${invite.invite.public.identity}",
-                            style: TextStyle(
-                                color: textColor,
-                                fontSize: theme.getMediumFont(context),
-                                fontWeight: FontWeight.w300)),
-                        const SizedBox(height: 34),
-                        ElevatedButton(
-                            onPressed: !_loading
-                                ? () => onAcceptInvite(context, invite)
-                                : null,
-                            child: const Text("Accept")),
-                        Container(height: 10),
-                        ElevatedButton(
-                            style: ElevatedButton.styleFrom(
-                                backgroundColor: errorColor),
-                            onPressed: () => onDenyInvite(context),
-                            child: const Text("Deny")),
-                        const Expanded(child: Empty()),
-                      ]))
-                ]))));
+    return StartupScreen(Consumer<ThemeNotifier>(
+        builder: (context, theme, child) => Column(children: [
+              const Expanded(child: Empty()),
+              Text("Accept Invite",
+                  style: TextStyle(
+                      color: theme.getTheme().dividerColor,
+                      fontSize: theme.getHugeFont(context),
+                      fontWeight: FontWeight.w200)),
+              const SizedBox(height: 34),
+              invite.invite.funds != null
+                  ? buildFundsWidget(context, invite.invite.funds!)
+                  : const Empty(),
+              const SizedBox(height: 20),
+              Text("Name: ${invite.invite.public.name}",
+                  style: TextStyle(
+                      color: theme.getTheme().dividerColor,
+                      fontSize: theme.getMediumFont(context),
+                      fontWeight: FontWeight.w300)),
+              Text("Nick: ${invite.invite.public.nick}",
+                  style: TextStyle(
+                      color: theme.getTheme().dividerColor,
+                      fontSize: theme.getMediumFont(context),
+                      fontWeight: FontWeight.w300)),
+              Text("Identity: ${invite.invite.public.identity}",
+                  style: TextStyle(
+                      color: theme.getTheme().dividerColor,
+                      fontSize: theme.getMediumFont(context),
+                      fontWeight: FontWeight.w300)),
+              const SizedBox(height: 34),
+              ElevatedButton(
+                  onPressed:
+                      !_loading ? () => onAcceptInvite(context, invite) : null,
+                  child: const Text("Accept")),
+              Container(height: 10),
+              ElevatedButton(
+                  style: ElevatedButton.styleFrom(backgroundColor: errorColor),
+                  onPressed: () => onDenyInvite(context),
+                  child: const Text("Deny")),
+              const Expanded(child: Empty()),
+            ])));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/verify_server.dart
+++ b/bruig/flutterui/bruig/lib/screens/verify_server.dart
@@ -1,3 +1,4 @@
+import 'package:bruig/screens/startupscreen.dart';
 import 'package:flutter/material.dart';
 import 'package:golib_plugin/definitions.dart';
 import 'package:golib_plugin/golib_plugin.dart';
@@ -26,60 +27,31 @@ class _VerifyServerScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var backgroundColor = const Color(0xFF19172C);
-    var cardColor = const Color(0xFF05031A);
-    var textColor = const Color(0xFF8E8D98);
-    return Consumer<ThemeNotifier>(
-        builder: (context, theme, child) => Scaffold(
-            body: Container(
-                color: backgroundColor,
-                child: Stack(children: [
-                  Container(
-                      decoration: const BoxDecoration(
-                          image: DecorationImage(
-                              fit: BoxFit.fill,
-                              image:
-                                  AssetImage("assets/images/loading-bg.png")))),
-                  Container(
-                      decoration: BoxDecoration(
-                          gradient: LinearGradient(
-                              begin: Alignment.bottomLeft,
-                              end: Alignment.topRight,
-                              colors: [
-                            cardColor,
-                            const Color(0xFF07051C),
-                            backgroundColor.withOpacity(0.34),
-                          ],
-                              stops: const [
-                            0,
-                            0.17,
-                            1
-                          ])),
-                      padding: const EdgeInsets.all(10),
-                      child: Column(children: [
-                        const SizedBox(height: 258),
-                        Text("Accept Server Fingerprint",
-                            style: TextStyle(
-                                color: textColor,
-                                fontSize: theme.getHugeFont(context),
-                                fontWeight: FontWeight.w200)),
-                        const SizedBox(height: 34),
-                        Text("Inner Fingerprint: ${cert.innerFingerprint}",
-                            style: TextStyle(
-                                color: textColor,
-                                fontSize: theme.getMediumFont(context),
-                                fontWeight: FontWeight.w300)),
-                        Text("Outer Fingerprint: ${cert.outerFingerprint}",
-                            style: TextStyle(
-                                color: textColor,
-                                fontSize: theme.getMediumFont(context),
-                                fontWeight: FontWeight.w300)),
-                        const SizedBox(height: 34),
-                        ElevatedButton(
-                            onPressed: () => onAcceptServerCreds(context),
-                            child: const Text("Accept")),
-                        Container(height: 10)
-                      ]))
-                ]))));
+    return StartupScreen(Consumer<ThemeNotifier>(
+        builder: (context, theme, child) => Column(children: [
+              const SizedBox(height: 258),
+              Text("Accept Server Fingerprint",
+                  style: TextStyle(
+                      color: theme.getTheme().dividerColor,
+                      fontSize: theme.getHugeFont(context),
+                      fontWeight: FontWeight.w200)),
+              const SizedBox(height: 34),
+              Text("Inner Fingerprint: ${cert.innerFingerprint}",
+                  style: TextStyle(
+                      color: theme.getTheme().dividerColor,
+                      fontSize: theme.getMediumFont(context),
+                      fontWeight: FontWeight.w300)),
+              Text("Outer Fingerprint: ${cert.outerFingerprint}",
+                  style: TextStyle(
+                      color: theme.getTheme().dividerColor,
+                      fontSize: theme.getMediumFont(context),
+                      fontWeight: FontWeight.w300)),
+              const SizedBox(height: 34),
+              ElevatedButton(
+                  onPressed: () => onAcceptServerCreds(context),
+                  child: const Text("Accept")),
+              Container(height: 10)
+            ])));
+    ;
   }
 }

--- a/bruig/flutterui/bruig/lib/theme_manager.dart
+++ b/bruig/flutterui/bruig/lib/theme_manager.dart
@@ -51,31 +51,31 @@ class ThemeNotifier with ChangeNotifier {
       fontFamily: "Inter",
       fontFamilyFallback: [emojifont],
       //primarySwatch: Colors.blue,
-      primaryColor: Colors.black,
-      brightness: Brightness.dark,
-      backgroundColor: const Color(0xFF19172C),
-      highlightColor: const Color(0xFF252438),
-      dividerColor: const Color(0xFF8E8D98),
-      canvasColor: const Color(0xFF05031A),
-      cardColor: const Color(0xFF05031A),
+      primaryColor: Colors.white,
+      brightness: Brightness.light,
+      backgroundColor: Color(0xFFE8E7F0),
+      highlightColor: Color(0xFFDFDFE9),
+      dividerColor: Color(0xFF232225),
+      canvasColor: Color(0xFFEDEBF8),
+      cardColor: Color(0xFFEDEBF8),
       errorColor: Colors.red,
-      focusColor: const Color(0xFFE4E3E6),
-      hoverColor: const Color(0xFF121026),
-      scaffoldBackgroundColor: const Color(0xFF19172C),
+      focusColor: Color(0xFF06030A),
+      hoverColor: Color(0xFFDFDDEC),
+      scaffoldBackgroundColor: Color(0xFFE8E7F3),
       bottomAppBarColor: const Color(0xFF0175CE),
-      indicatorColor: const Color(0xFF5A5968),
-      selectedRowColor: Colors.black38,
+      indicatorColor: Color(0xFF3A3A3F),
+      selectedRowColor: Colors.white38,
       shadowColor: const Color(0xFFE44B00),
-      dialogBackgroundColor: const Color(0xFF3A384B),
-      iconTheme: const IconThemeData(color: Color(0xFF8E8D98)),
+      dialogBackgroundColor: Color(0xFF6C6B74),
+      iconTheme: const IconThemeData(color: Color.fromARGB(255, 101, 100, 110)),
       textTheme: const TextTheme(
           headline5: TextStyle(
-            color: Colors.white,
+            color: Colors.black,
             fontSize: 46,
             fontWeight: FontWeight.w800,
           ),
-          bodyText1: TextStyle(color: Colors.white),
-          bodyText2: TextStyle(color: Colors.black)));
+          bodyText1: TextStyle(color: Colors.black),
+          bodyText2: TextStyle(color: Colors.white)));
 
   late ThemeData _themeData = lightTheme;
   ThemeData getTheme() => _themeData;
@@ -125,9 +125,27 @@ class ThemeNotifier with ChangeNotifier {
       var themeMode = value ?? 'light';
       if (themeMode == 'light') {
         _themeData = lightTheme;
-      } else {
+      } else if (themeMode == 'dark') {
         debugPrint('setting dark theme');
         _themeData = darkTheme;
+      } else if (themeMode == 'system') {
+        // only check system if on mobile
+        if (Platform.isIOS || Platform.isAndroid) {
+          debugPrint('setting system theme');
+          var brightness =
+              WidgetsBinding.instance.platformDispatcher.platformBrightness;
+          if (brightness == Brightness.light) {
+            _themeData = lightTheme;
+          } else if (brightness == Brightness.dark) {
+            _themeData = darkTheme;
+          } else {
+            _themeData = lightTheme;
+          }
+        } else {
+          _themeData = lightTheme;
+        }
+      } else {
+        _themeData = lightTheme;
       }
       notifyListeners();
     });
@@ -147,6 +165,12 @@ class ThemeNotifier with ChangeNotifier {
   void setLightMode() async {
     _themeData = lightTheme;
     StorageManager.saveData('themeMode', 'light');
+    notifyListeners();
+  }
+
+  void setSystemMode() async {
+    _themeData = lightTheme;
+    StorageManager.saveData('themeMode', 'system');
     notifyListeners();
   }
 

--- a/bruig/flutterui/bruig/lib/theme_manager.dart
+++ b/bruig/flutterui/bruig/lib/theme_manager.dart
@@ -55,7 +55,7 @@ class ThemeNotifier with ChangeNotifier {
       brightness: Brightness.light,
       backgroundColor: Color(0xFFE8E7F0),
       highlightColor: Color(0xFFDFDFE9),
-      dividerColor: Color(0xFF232225),
+      dividerColor: Color.fromARGB(255, 104, 101, 110),
       canvasColor: Color(0xFFEDEBF8),
       cardColor: Color(0xFFEDEBF8),
       errorColor: Colors.red,
@@ -63,7 +63,7 @@ class ThemeNotifier with ChangeNotifier {
       hoverColor: Color(0xFFDFDDEC),
       scaffoldBackgroundColor: Color(0xFFE8E7F3),
       bottomAppBarColor: const Color(0xFF0175CE),
-      indicatorColor: Color(0xFF3A3A3F),
+      indicatorColor: const Color(0xFF5A5968),
       selectedRowColor: Colors.white38,
       shadowColor: const Color(0xFFE44B00),
       dialogBackgroundColor: Color(0xFF6C6B74),
@@ -79,6 +79,9 @@ class ThemeNotifier with ChangeNotifier {
 
   late ThemeData _themeData = lightTheme;
   ThemeData getTheme() => _themeData;
+
+  late String _themeMode = "";
+  String getThemeMode() => _themeMode;
 
   late double _fontSize = defaultFontSize;
   double getFontCoef() => _fontSize;
@@ -125,10 +128,13 @@ class ThemeNotifier with ChangeNotifier {
       var themeMode = value ?? 'light';
       if (themeMode == 'light') {
         _themeData = lightTheme;
+        _themeMode = 'light';
       } else if (themeMode == 'dark') {
         debugPrint('setting dark theme');
         _themeData = darkTheme;
+        _themeMode = 'dark';
       } else if (themeMode == 'system') {
+        _themeMode = 'system';
         // only check system if on mobile
         if (Platform.isIOS || Platform.isAndroid) {
           debugPrint('setting system theme');
@@ -145,6 +151,7 @@ class ThemeNotifier with ChangeNotifier {
           _themeData = lightTheme;
         }
       } else {
+        _themeMode = 'light';
         _themeData = lightTheme;
       }
       notifyListeners();
@@ -157,19 +164,30 @@ class ThemeNotifier with ChangeNotifier {
   }
 
   void setDarkMode() async {
+    _themeMode = 'dark';
     _themeData = darkTheme;
     StorageManager.saveData('themeMode', 'dark');
     notifyListeners();
   }
 
   void setLightMode() async {
+    _themeMode = 'light';
     _themeData = lightTheme;
     StorageManager.saveData('themeMode', 'light');
     notifyListeners();
   }
 
   void setSystemMode() async {
-    _themeData = lightTheme;
+    _themeMode = 'system';
+    var brightness =
+        WidgetsBinding.instance.platformDispatcher.platformBrightness;
+    if (brightness == Brightness.light) {
+      _themeData = lightTheme;
+    } else if (brightness == Brightness.dark) {
+      _themeData = darkTheme;
+    } else {
+      _themeData = lightTheme;
+    }
     StorageManager.saveData('themeMode', 'system');
     notifyListeners();
   }


### PR DESCRIPTION
This PR adds the ability to select a 'light' theme as well as let the system default be used.  

I've also removed any extraneous colors that were hard coded in and use the theme manager for all colors.  

This also introduces a reused widget for Startup Screen to make sure the startup funnel is consistently styled.