### PR TITLE
bruig: Fix keyboard working message

### DIFF
--- a/bruig/flutterui/bruig/lib/components/chat/input.dart
+++ b/bruig/flutterui/bruig/lib/components/chat/input.dart
@@ -66,11 +66,8 @@ class _InputState extends State<Input> {
   void handleKeyPress(event) {
     if (event is RawKeyUpEvent) {
       bool modPressed = event.isShiftPressed || event.isControlPressed;
-      final val = controller.value;
       if (event.data.logicalKey.keyLabel == "Enter" && !modPressed) {
         sendMsg();
-      } else {
-        widget.chat.workingMsg = val.text.trim();
       }
     }
   }
@@ -104,6 +101,7 @@ class _InputState extends State<Input> {
               child: Container(
                   margin: const EdgeInsets.only(bottom: 5),
                   child: TextField(
+                    onChanged: (value) => widget.chat.workingMsg = value,
                     autofocus: isScreenSmall ? false : true,
                     focusNode: widget.inputFocusNode,
                     style: TextStyle(


### PR DESCRIPTION
Close #417 
Close #66 

I believe this should fix most of the issues we've seen with strange clearing of the input area on mobile and various times on desktop.  The 'working message' is now stored in the Chat model, and is only updated when the TextField is changed, the message is sent or something is attached.  Previously there were other ways that the update was occurring which may have led to these weird outcomes (especially on mobile since the KeyUpEvent is not triggered from the on screen keyboard.)

We'll keep monitoring keyboard issues that are reported and may come back to this if other issues are found.