### PR TITLE
bruig: Streamline StartupScreen usage

### DIFF
--- a/bruig/flutterui/bruig/lib/components/addressbook/input.dart
+++ b/bruig/flutterui/bruig/lib/components/addressbook/input.dart
@@ -154,8 +154,6 @@ class _GroupChatNameInputState extends State<GroupChatNameInput> {
   void handleKeyPress(event) {
     if (event is RawKeyUpEvent) {
       bool modPressed = event.isShiftPressed || event.isControlPressed;
-      final val = controller.value;
-      //client.filteredSearchString = val.text;
       if (event.data.logicalKey.keyLabel == "Enter" && !modPressed) {
         controller.value = const TextEditingValue(
             text: "", selection: TextSelection.collapsed(offset: 0));

--- a/bruig/flutterui/bruig/lib/components/buttons.dart
+++ b/bruig/flutterui/bruig/lib/components/buttons.dart
@@ -177,29 +177,20 @@ class FeedReadMoreButton extends StatelessWidget {
 // Generic about button.
 class AboutButton extends StatelessWidget {
   const AboutButton({super.key});
-
   @override
   Widget build(BuildContext context) {
-    return IconButton(
-        alignment: Alignment.topLeft,
-        tooltip: "About Bison Relay",
-        iconSize: 50,
-        onPressed: () {
-          Navigator.of(context).pushNamed("/about");
-        },
-        icon: Image.asset(
-          "assets/images/icon.png",
-        ));
-  }
-}
-
-// About button meant to be used in the initial setup screens.
-class SetupScreenAbountButton extends StatelessWidget {
-  const SetupScreenAbountButton({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return const Flexible(
-        child: Align(alignment: Alignment.topLeft, child: AboutButton()));
+    bool isScreenSmall = MediaQuery.of(context).size.width <= 500;
+    return SizedBox(
+        height: isScreenSmall ? 100 : 150,
+        width: isScreenSmall ? 100 : 150,
+        child: IconButton(
+            alignment: Alignment.topLeft,
+            tooltip: "About Bison Relay",
+            onPressed: () {
+              Navigator.of(context).pushNamed("/about");
+            },
+            icon: Image.asset(
+              "assets/images/icon.png",
+            )));
   }
 }

--- a/bruig/flutterui/bruig/lib/components/buttons.dart
+++ b/bruig/flutterui/bruig/lib/components/buttons.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:bruig/theme_manager.dart';
+import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 
 class CancelButton extends StatelessWidget {
@@ -179,18 +180,14 @@ class AboutButton extends StatelessWidget {
   const AboutButton({super.key});
   @override
   Widget build(BuildContext context) {
-    bool isScreenSmall = MediaQuery.of(context).size.width <= 500;
-    return SizedBox(
-        height: isScreenSmall ? 100 : 150,
-        width: isScreenSmall ? 100 : 150,
-        child: IconButton(
-            alignment: Alignment.topLeft,
-            tooltip: "About Bison Relay",
-            onPressed: () {
-              Navigator.of(context).pushNamed("/about");
-            },
-            icon: Image.asset(
-              "assets/images/icon.png",
-            )));
+    return IconButton(
+        tooltip: "About Bison Relay",
+        onPressed: () {
+          Navigator.of(context).pushNamed("/about");
+        },
+        icon: Image.asset(
+          fit: BoxFit.contain,
+          "assets/images/icon.png",
+        ));
   }
 }

--- a/bruig/flutterui/bruig/lib/components/chat/active_chat.dart
+++ b/bruig/flutterui/bruig/lib/components/chat/active_chat.dart
@@ -116,7 +116,7 @@ class _ActiveChatState extends State<ActiveChat> {
     var selectedBackgroundColor = theme.highlightColor;
     var subMenuBorderColor = theme.canvasColor;
     var hightLightTextColor = theme.focusColor; // NAME TEXT COLOR
-    var avatarColor = colorFromNick(chat!.nick);
+    var avatarColor = colorFromNick(chat.nick);
     var avatarTextColor =
         ThemeData.estimateBrightnessForColor(avatarColor) == Brightness.dark
             ? hightLightTextColor

--- a/bruig/flutterui/bruig/lib/components/chat/messages.dart
+++ b/bruig/flutterui/bruig/lib/components/chat/messages.dart
@@ -35,7 +35,6 @@ class _MessagesState extends State<Messages> {
   String get nick => widget.nick;
   int _maxItem = 0;
   bool _showFAB = false;
-  late ChatModel _lastChat;
   Timer? _debounce;
 
   void onChatChanged() {
@@ -80,7 +79,6 @@ class _MessagesState extends State<Messages> {
     chat.addListener(onChatChanged);
     _maybeScrollToFirstUnread();
     _maybeScrollToBottom();
-    _lastChat = chat;
   }
 
   @override
@@ -91,7 +89,6 @@ class _MessagesState extends State<Messages> {
     _maybeScrollToFirstUnread();
     _maybeScrollToBottom();
     onChatChanged();
-    _lastChat = chat;
   }
 
   @override

--- a/bruig/flutterui/bruig/lib/components/snackbars.dart
+++ b/bruig/flutterui/bruig/lib/components/snackbars.dart
@@ -5,8 +5,8 @@ import 'package:bruig/theme_manager.dart';
 import 'package:provider/provider.dart';
 
 class SnackbarDisplayer extends StatefulWidget {
-  SnackBarModel snackBar;
-  Widget child;
+  final SnackBarModel snackBar;
+  final Widget child;
   SnackbarDisplayer(this.snackBar, this.child, {super.key});
 
   @override

--- a/bruig/flutterui/bruig/lib/components/users_dropdown.dart
+++ b/bruig/flutterui/bruig/lib/components/users_dropdown.dart
@@ -139,10 +139,10 @@ class _UsersDropdownState extends State<UsersDropdown> {
           dropdownStyleData: const DropdownStyleData(maxHeight: 200),
           menuItemStyleData: MenuItemStyleData(
             overlayColor: MaterialStateProperty.resolveWith((states) {
-              // If the button is pressed, return green, otherwise blue
               if (states.contains(MaterialState.hovered)) {
                 return backgroundColor;
               }
+              return highlightColor;
             }),
             height: 40,
           ),

--- a/bruig/flutterui/bruig/lib/models/client.dart
+++ b/bruig/flutterui/bruig/lib/models/client.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:collection';
 
-import 'package:bruig/components/gc_context_menu.dart';
 import 'package:bruig/models/menus.dart';
 import 'package:bruig/models/resources.dart';
 import 'package:flutter/foundation.dart';

--- a/bruig/flutterui/bruig/lib/models/menus.dart
+++ b/bruig/flutterui/bruig/lib/models/menus.dart
@@ -1,4 +1,3 @@
-import 'package:bruig/components/chats_list.dart';
 import 'package:bruig/components/confirmation_dialog.dart';
 import 'package:bruig/components/pay_tip.dart';
 import 'package:bruig/components/rename_chat.dart';

--- a/bruig/flutterui/bruig/lib/screens/about.dart
+++ b/bruig/flutterui/bruig/lib/screens/about.dart
@@ -38,115 +38,109 @@ class _AboutScreenState extends State<AboutScreen> {
   Widget build(BuildContext context) {
     bool isScreenSmall = MediaQuery.of(context).size.width <= 500;
 
-    return StartupScreen(
-        about: true,
-        Consumer<ThemeNotifier>(
-            builder: (context, theme, child) => Column(
+    return Consumer<ThemeNotifier>(
+        builder: (context, theme, child) => StartupScreen(
+              about: true,
+              [
+                const SizedBox(height: 89),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    const SizedBox(height: 89),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Flexible(
-                            child: Align(
-                                child: SizedBox(
-                                    width: 600,
-                                    height: 300,
-                                    child: Container(
-                                        padding: const EdgeInsets.all(10),
-                                        decoration: BoxDecoration(
-                                          borderRadius: const BorderRadius.all(
-                                              Radius.circular(30)),
-                                          border: Border.all(
-                                              color:
-                                                  theme.getTheme().focusColor),
-                                        ),
-                                        child: Flex(
-                                            direction: isScreenSmall
-                                                ? Axis.vertical
-                                                : Axis.horizontal,
+                    Flexible(
+                        child: Align(
+                            child: SizedBox(
+                                width: 600,
+                                height: 300,
+                                child: Container(
+                                    padding: const EdgeInsets.all(10),
+                                    decoration: BoxDecoration(
+                                      borderRadius: const BorderRadius.all(
+                                          Radius.circular(30)),
+                                      border: Border.all(
+                                          color: theme.getTheme().focusColor),
+                                    ),
+                                    child: Flex(
+                                        direction: isScreenSmall
+                                            ? Axis.vertical
+                                            : Axis.horizontal,
+                                        children: [
+                                          Image.asset(
+                                            "assets/images/icon.png",
+                                            width: isScreenSmall ? 100 : 200,
+                                            height: isScreenSmall ? 100 : 200,
+                                          ),
+                                          Column(
+                                            mainAxisAlignment:
+                                                MainAxisAlignment.center,
                                             children: [
-                                              Image.asset(
-                                                "assets/images/icon.png",
-                                                width:
-                                                    isScreenSmall ? 100 : 200,
-                                                height:
-                                                    isScreenSmall ? 100 : 200,
-                                              ),
-                                              Column(
-                                                mainAxisAlignment:
-                                                    MainAxisAlignment.center,
-                                                children: [
-                                                  Text(
-                                                      textAlign: TextAlign.left,
-                                                      "Bison Relay",
-                                                      style: TextStyle(
-                                                          color: theme
-                                                              .getTheme()
-                                                              .focusColor,
-                                                          fontSize:
-                                                              theme.getHugeFont(
-                                                                  context),
-                                                          fontWeight:
-                                                              FontWeight.w200)),
-                                                  const SizedBox(height: 10),
-                                                  Text("Version $version",
-                                                      style: TextStyle(
-                                                          color: theme
-                                                              .getTheme()
-                                                              .focusColor,
-                                                          fontSize: theme
-                                                              .getLargeFont(
-                                                                  context),
-                                                          fontWeight:
-                                                              FontWeight.w200)),
-                                                  const SizedBox(height: 10),
-                                                  RichText(
-                                                      text: TextSpan(children: [
-                                                    WidgetSpan(
-                                                        alignment:
-                                                            PlaceholderAlignment
-                                                                .middle,
-                                                        child: Icon(
-                                                            color: theme
-                                                                .getTheme()
-                                                                .focusColor,
-                                                            size: theme
-                                                                .getMediumFont(
-                                                                    context),
-                                                            Icons.copyright)),
-                                                    TextSpan(
-                                                        text:
-                                                            "2022-2024 Company 0, LLC",
-                                                        style: TextStyle(
-                                                            color: theme
-                                                                .getTheme()
-                                                                .focusColor,
-                                                            fontSize: theme
-                                                                .getLargeFont(
-                                                                    context),
-                                                            fontWeight:
-                                                                FontWeight
-                                                                    .w200))
-                                                  ]))
-                                                ],
-                                              )
-                                            ]))))),
-                      ],
-                    ),
-                    const SizedBox(height: 89),
-                    widget.settings
-                        ? const Empty()
-                        : Row(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                                LoadingScreenButton(
-                                  empty: true,
-                                  onPressed: () => goBack(context),
-                                  text: "Go Back",
-                                ),
-                              ]),
+                                              Text(
+                                                  textAlign: TextAlign.left,
+                                                  "Bison Relay",
+                                                  style: TextStyle(
+                                                      color: theme
+                                                          .getTheme()
+                                                          .focusColor,
+                                                      fontSize: theme
+                                                          .getHugeFont(context),
+                                                      fontWeight:
+                                                          FontWeight.w200)),
+                                              const SizedBox(height: 10),
+                                              Text("Version $version",
+                                                  style: TextStyle(
+                                                      color: theme
+                                                          .getTheme()
+                                                          .focusColor,
+                                                      fontSize:
+                                                          theme.getLargeFont(
+                                                              context),
+                                                      fontWeight:
+                                                          FontWeight.w200)),
+                                              const SizedBox(height: 10),
+                                              RichText(
+                                                  text: TextSpan(children: [
+                                                WidgetSpan(
+                                                    alignment:
+                                                        PlaceholderAlignment
+                                                            .middle,
+                                                    child: Icon(
+                                                        color: theme
+                                                            .getTheme()
+                                                            .focusColor,
+                                                        size:
+                                                            theme.getMediumFont(
+                                                                context),
+                                                        Icons.copyright)),
+                                                TextSpan(
+                                                    text:
+                                                        "2022-2024 Company 0, LLC",
+                                                    style: TextStyle(
+                                                        color: theme
+                                                            .getTheme()
+                                                            .focusColor,
+                                                        fontSize:
+                                                            theme.getLargeFont(
+                                                                context),
+                                                        fontWeight:
+                                                            FontWeight.w200))
+                                              ]))
+                                            ],
+                                          )
+                                        ]))))),
                   ],
-                )));
+                ),
+                const SizedBox(height: 89),
+                widget.settings
+                    ? const Empty()
+                    : Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                            LoadingScreenButton(
+                              empty: true,
+                              onPressed: () => goBack(context),
+                              text: "Go Back",
+                            ),
+                          ]),
+              ],
+            ));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/about.dart
+++ b/bruig/flutterui/bruig/lib/screens/about.dart
@@ -38,108 +38,115 @@ class _AboutScreenState extends State<AboutScreen> {
   Widget build(BuildContext context) {
     bool isScreenSmall = MediaQuery.of(context).size.width <= 500;
 
-    return StartupScreen(Consumer<ThemeNotifier>(
-        builder: (context, theme, child) => Column(
-              children: [
-                const SizedBox(height: 89),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
+    return StartupScreen(
+        about: true,
+        Consumer<ThemeNotifier>(
+            builder: (context, theme, child) => Column(
                   children: [
-                    Flexible(
-                        child: Align(
-                            child: SizedBox(
-                                width: 600,
-                                height: 300,
-                                child: Container(
-                                    padding: const EdgeInsets.all(10),
-                                    decoration: BoxDecoration(
-                                      borderRadius: const BorderRadius.all(
-                                          Radius.circular(30)),
-                                      border: Border.all(
-                                          color: theme.getTheme().focusColor),
-                                    ),
-                                    child: Flex(
-                                        direction: isScreenSmall
-                                            ? Axis.vertical
-                                            : Axis.horizontal,
-                                        children: [
-                                          Image.asset(
-                                            "assets/images/icon.png",
-                                            width: isScreenSmall ? 100 : 200,
-                                            height: isScreenSmall ? 100 : 200,
-                                          ),
-                                          Column(
-                                            mainAxisAlignment:
-                                                MainAxisAlignment.center,
+                    const SizedBox(height: 89),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Flexible(
+                            child: Align(
+                                child: SizedBox(
+                                    width: 600,
+                                    height: 300,
+                                    child: Container(
+                                        padding: const EdgeInsets.all(10),
+                                        decoration: BoxDecoration(
+                                          borderRadius: const BorderRadius.all(
+                                              Radius.circular(30)),
+                                          border: Border.all(
+                                              color:
+                                                  theme.getTheme().focusColor),
+                                        ),
+                                        child: Flex(
+                                            direction: isScreenSmall
+                                                ? Axis.vertical
+                                                : Axis.horizontal,
                                             children: [
-                                              Text(
-                                                  textAlign: TextAlign.left,
-                                                  "Bison Relay",
-                                                  style: TextStyle(
-                                                      color: theme
-                                                          .getTheme()
-                                                          .focusColor,
-                                                      fontSize: theme
-                                                          .getHugeFont(context),
-                                                      fontWeight:
-                                                          FontWeight.w200)),
-                                              const SizedBox(height: 10),
-                                              Text("Version $version",
-                                                  style: TextStyle(
-                                                      color: theme
-                                                          .getTheme()
-                                                          .focusColor,
-                                                      fontSize:
-                                                          theme.getLargeFont(
-                                                              context),
-                                                      fontWeight:
-                                                          FontWeight.w200)),
-                                              const SizedBox(height: 10),
-                                              RichText(
-                                                  text: TextSpan(children: [
-                                                WidgetSpan(
-                                                    alignment:
-                                                        PlaceholderAlignment
-                                                            .middle,
-                                                    child: Icon(
-                                                        color: theme
-                                                            .getTheme()
-                                                            .focusColor,
-                                                        size:
-                                                            theme.getMediumFont(
-                                                                context),
-                                                        Icons.copyright)),
-                                                TextSpan(
-                                                    text:
-                                                        "2022-2024 Company 0, LLC",
-                                                    style: TextStyle(
-                                                        color: theme
-                                                            .getTheme()
-                                                            .focusColor,
-                                                        fontSize:
-                                                            theme.getLargeFont(
-                                                                context),
-                                                        fontWeight:
-                                                            FontWeight.w200))
-                                              ]))
-                                            ],
-                                          )
-                                        ]))))),
+                                              Image.asset(
+                                                "assets/images/icon.png",
+                                                width:
+                                                    isScreenSmall ? 100 : 200,
+                                                height:
+                                                    isScreenSmall ? 100 : 200,
+                                              ),
+                                              Column(
+                                                mainAxisAlignment:
+                                                    MainAxisAlignment.center,
+                                                children: [
+                                                  Text(
+                                                      textAlign: TextAlign.left,
+                                                      "Bison Relay",
+                                                      style: TextStyle(
+                                                          color: theme
+                                                              .getTheme()
+                                                              .focusColor,
+                                                          fontSize:
+                                                              theme.getHugeFont(
+                                                                  context),
+                                                          fontWeight:
+                                                              FontWeight.w200)),
+                                                  const SizedBox(height: 10),
+                                                  Text("Version $version",
+                                                      style: TextStyle(
+                                                          color: theme
+                                                              .getTheme()
+                                                              .focusColor,
+                                                          fontSize: theme
+                                                              .getLargeFont(
+                                                                  context),
+                                                          fontWeight:
+                                                              FontWeight.w200)),
+                                                  const SizedBox(height: 10),
+                                                  RichText(
+                                                      text: TextSpan(children: [
+                                                    WidgetSpan(
+                                                        alignment:
+                                                            PlaceholderAlignment
+                                                                .middle,
+                                                        child: Icon(
+                                                            color: theme
+                                                                .getTheme()
+                                                                .focusColor,
+                                                            size: theme
+                                                                .getMediumFont(
+                                                                    context),
+                                                            Icons.copyright)),
+                                                    TextSpan(
+                                                        text:
+                                                            "2022-2024 Company 0, LLC",
+                                                        style: TextStyle(
+                                                            color: theme
+                                                                .getTheme()
+                                                                .focusColor,
+                                                            fontSize: theme
+                                                                .getLargeFont(
+                                                                    context),
+                                                            fontWeight:
+                                                                FontWeight
+                                                                    .w200))
+                                                  ]))
+                                                ],
+                                              )
+                                            ]))))),
+                      ],
+                    ),
+                    const SizedBox(height: 89),
+                    widget.settings
+                        ? const Empty()
+                        : Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                                LoadingScreenButton(
+                                  empty: true,
+                                  onPressed: () => goBack(context),
+                                  text: "Go Back",
+                                ),
+                              ]),
                   ],
-                ),
-                const SizedBox(height: 89),
-                widget.settings
-                    ? const Empty()
-                    : Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                            LoadingScreenButton(
-                              empty: true,
-                              onPressed: () => goBack(context),
-                              text: "Go Back",
-                            ),
-                          ]),
-              ],
-            )));
+                )));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/feed.dart
+++ b/bruig/flutterui/bruig/lib/screens/feed.dart
@@ -97,7 +97,10 @@ class _FeedScreenState extends State<FeedScreen> {
   }
 
   void onItemChanged(int index, PostContentScreenArgs? args) {
-    setState(() => {showPost = args, tabIndex = index});
+    setState(() {
+      showPost = args;
+      tabIndex = index;
+    });
     Timer(const Duration(milliseconds: 1),
         () async => widget.mainMenu.activePageTab = index);
   }

--- a/bruig/flutterui/bruig/lib/screens/feed/post_content.dart
+++ b/bruig/flutterui/bruig/lib/screens/feed/post_content.dart
@@ -57,7 +57,6 @@ class _ReceiveReceipt extends StatelessWidget {
     var theme = Theme.of(context);
     var darkTextColor = theme.indicatorColor;
     var nick = client.getNick(rr.user);
-    var rrTxtStyle = TextStyle(color: darkTextColor);
     var rrdt =
         DateTime.fromMillisecondsSinceEpoch(rr.serverTime).toIso8601String();
 

--- a/bruig/flutterui/bruig/lib/screens/feed/user_posts.dart
+++ b/bruig/flutterui/bruig/lib/screens/feed/user_posts.dart
@@ -8,7 +8,6 @@ import 'package:golib_plugin/definitions.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:bruig/components/user_context_menu.dart';
 import 'package:bruig/util.dart';
-import 'package:provider/provider.dart';
 import 'package:bruig/theme_manager.dart';
 
 class UserPostW extends StatefulWidget {

--- a/bruig/flutterui/bruig/lib/screens/fetch_invite.dart
+++ b/bruig/flutterui/bruig/lib/screens/fetch_invite.dart
@@ -70,9 +70,8 @@ class _FetchInviteScreenState extends State<FetchInviteScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return StartupScreen(Consumer<ThemeNotifier>(
-        builder: (context, theme, child) =>
-            Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+    return Consumer<ThemeNotifier>(
+        builder: (context, theme, child) => StartupScreen([
               const Expanded(child: Empty()),
               Text("Fetch Invite",
                   style: TextStyle(
@@ -110,6 +109,6 @@ class _FetchInviteScreenState extends State<FetchInviteScreen> {
               ElevatedButton(
                   onPressed: () => Navigator.pop(context),
                   child: const Text("Cancel"))
-            ])));
+            ]));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/generate_invite.dart
+++ b/bruig/flutterui/bruig/lib/screens/generate_invite.dart
@@ -218,10 +218,8 @@ class _GenerateInviteScreenState extends State<GenerateInviteScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return StartupScreen(Consumer<ThemeNotifier>(
-        builder: (context, theme, child) =>
-            Column(mainAxisAlignment: MainAxisAlignment.center, children: [
-              const Expanded(child: Empty()),
+    return Consumer<ThemeNotifier>(
+        builder: (context, theme, child) => StartupScreen([
               Text("Generate Invite",
                   style: TextStyle(
                       color: theme.getTheme().dividerColor,
@@ -231,6 +229,6 @@ class _GenerateInviteScreenState extends State<GenerateInviteScreen> {
               ...(generated == null
                   ? buildGeneratePanel(context)
                   : buildGeneratedInvite(context)),
-            ])));
+            ]));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/init_local_id.dart
+++ b/bruig/flutterui/bruig/lib/screens/init_local_id.dart
@@ -42,8 +42,8 @@ class InitLocalIDScreenState extends State<InitLocalIDScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return StartupScreen(Consumer<ThemeNotifier>(
-      builder: (context, theme, child) => Column(children: [
+    return Consumer<ThemeNotifier>(
+      builder: (context, theme, child) => StartupScreen([
         const SizedBox(height: 89),
         Text("Setting up Bison Relay",
             style: TextStyle(
@@ -88,6 +88,6 @@ class InitLocalIDScreenState extends State<InitLocalIDScreen> {
               ]))
         ]),
       ]),
-    ));
+    );
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/ln/onchain.dart
+++ b/bruig/flutterui/bruig/lib/screens/ln/onchain.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:bruig/components/accounts_dropdown.dart';
 import 'package:bruig/components/copyable.dart';
 import 'package:bruig/components/dcr_input.dart';

--- a/bruig/flutterui/bruig/lib/screens/log.dart
+++ b/bruig/flutterui/bruig/lib/screens/log.dart
@@ -104,7 +104,7 @@ class _ExportLogScreenState extends State<ExportLogScreen> {
     () async {
       try {
         var dir = isMobile
-            ? (await getApplicationCacheDirectory())?.path
+            ? (await getApplicationCacheDirectory()).path
             : await getDownloadsDirectory();
         setState(() {
           destPath = "$dir/${zipFilename()}";
@@ -197,8 +197,7 @@ class _ExportLogScreenState extends State<ExportLogScreen> {
                                   .pushNamed(ManualCfgModifyScreen.routeName);
                             }
                           },
-                          child: Container(
-                              height: 20, width: 40),
+                          child: Container(height: 20, width: 40),
                         ),
                   TextButton(
                       onPressed: chooseDestPath,

--- a/bruig/flutterui/bruig/lib/screens/manage_content/downloads.dart
+++ b/bruig/flutterui/bruig/lib/screens/manage_content/downloads.dart
@@ -2,7 +2,6 @@ import 'package:bruig/models/downloads.dart';
 import 'package:flutter/material.dart';
 import 'package:bruig/theme_manager.dart';
 import 'package:provider/provider.dart';
-import 'package:bruig/theme_manager.dart';
 
 class _FileDownloadW extends StatefulWidget {
   final FileDownloadModel fd;

--- a/bruig/flutterui/bruig/lib/screens/needs_funds.dart
+++ b/bruig/flutterui/bruig/lib/screens/needs_funds.dart
@@ -151,24 +151,22 @@ to redeem it by clicking in the button.
 
   @override
   Widget build(BuildContext context) {
-    return StartupScreen(
-      Consumer<ThemeNotifier>(
-          builder: (context, theme, child) => Column(
-                children: [
-                  const Expanded(child: Empty()),
-                  Text("Setting up Bison Relay",
-                      style: TextStyle(
-                          color: theme.getTheme().dividerColor,
-                          fontSize: theme.getHugeFont(context),
-                          fontWeight: FontWeight.w200)),
-                  const SizedBox(height: 20),
-                  Text("Receive Wallet Funds",
-                      style: TextStyle(
-                          color: theme.getTheme().focusColor,
-                          fontSize: theme.getLargeFont(context),
-                          fontWeight: FontWeight.w300)),
-                  const SizedBox(height: 20),
-                  Text('''
+    return Consumer<ThemeNotifier>(
+      builder: (context, theme, child) => StartupScreen(
+        [
+          Text("Setting up Bison Relay",
+              style: TextStyle(
+                  color: theme.getTheme().dividerColor,
+                  fontSize: theme.getHugeFont(context),
+                  fontWeight: FontWeight.w200)),
+          const SizedBox(height: 20),
+          Text("Receive Wallet Funds",
+              style: TextStyle(
+                  color: theme.getTheme().focusColor,
+                  fontSize: theme.getLargeFont(context),
+                  fontWeight: FontWeight.w300)),
+          const SizedBox(height: 20),
+          Text('''
 The wallet requires on-chain DCR funds to be able to open Lightning Network (LN) channels
 and perform payments to the server and other users of the Bison Relay network.
 
@@ -176,78 +174,76 @@ Send DCR funds to the following address to receive funds in your wallet. Note th
 wallet seed will be needed to recover these funds if the wallet data in this computer is
 corrupted or lost.
 ''',
-                      style: TextStyle(
-                          color: theme.getTheme().focusColor,
-                          fontSize: theme.getMediumFont(context),
-                          fontWeight: FontWeight.w300)),
-                  buildFundsWidget(context),
-                  const SizedBox(height: 13),
-                  Container(
-                      margin: const EdgeInsets.all(10),
-                      color: Colors.white,
-                      child: QrImageView(
-                        data: addr,
-                        version: QrVersions.auto,
-                        size: 200.0,
-                      )),
-                  const SizedBox(height: 13),
-                  Container(
-                      color: theme.getTheme().cardColor,
-                      padding: const EdgeInsets.only(
-                          left: 22, top: 18, right: 22, bottom: 18),
-                      child: Copyable(
-                          addr,
-                          TextStyle(
-                              color: theme.getTheme().dividerColor,
-                              fontSize: theme.getMediumFont(context)))),
-                  const SizedBox(height: 9),
-                  Container(
-                      padding: const EdgeInsets.only(
-                          left: 324 + 22, right: 324 + 20),
-                      child: Row(children: [
-                        Text(
-                            textAlign: TextAlign.left,
-                            "Unconfirmed wallet balance:",
-                            style: TextStyle(
-                                color: theme.getTheme().indicatorColor,
-                                fontSize: theme.getSmallFont(context),
-                                fontWeight: FontWeight.w300)),
-                        Text(
-                            textAlign: TextAlign.right,
-                            formatDCR(atomsToDCR(unconfirmedBalance)),
-                            style: TextStyle(
-                                color: theme.getTheme().indicatorColor,
-                                fontSize: theme.getSmallFont(context),
-                                fontWeight: FontWeight.w300)),
-                      ])),
-                  const SizedBox(height: 3),
-                  Container(
-                      padding: const EdgeInsets.only(
-                          left: 324 + 22, right: 324 + 20),
-                      child: Row(children: [
-                        Text(
-                            textAlign: TextAlign.left,
-                            "Confirmed wallet balance:",
-                            style: TextStyle(
-                                color: theme.getTheme().indicatorColor,
-                                fontSize: theme.getSmallFont(context),
-                                fontWeight: FontWeight.w300)),
-                        Text(
-                            textAlign: TextAlign.right,
-                            formatDCR(atomsToDCR(confirmedBalance)),
-                            style: TextStyle(
-                                color: theme.getTheme().indicatorColor,
-                                fontSize: theme.getSmallFont(context),
-                                fontWeight: FontWeight.w300))
-                      ])),
-                  const SizedBox(height: 20),
-                  LoadingScreenButton(
-                    onPressed: () => Navigator.of(context).pop(),
-                    text: "Finish",
-                  ),
-                  const Expanded(child: Empty()),
-                ],
+              style: TextStyle(
+                  color: theme.getTheme().focusColor,
+                  fontSize: theme.getMediumFont(context),
+                  fontWeight: FontWeight.w300)),
+          buildFundsWidget(context),
+          const SizedBox(height: 13),
+          Container(
+              margin: const EdgeInsets.all(10),
+              color: Colors.white,
+              child: QrImageView(
+                data: addr,
+                version: QrVersions.auto,
+                size: 200.0,
               )),
+          const SizedBox(height: 13),
+          Container(
+              color: theme.getTheme().cardColor,
+              padding: const EdgeInsets.only(
+                  left: 22, top: 18, right: 22, bottom: 18),
+              child: Copyable(
+                  addr,
+                  TextStyle(
+                      color: theme.getTheme().dividerColor,
+                      fontSize: theme.getMediumFont(context)))),
+          const SizedBox(height: 9),
+          Container(
+              padding: const EdgeInsets.only(left: 324 + 22, right: 324 + 20),
+              child: Row(children: [
+                Text(
+                    textAlign: TextAlign.left,
+                    "Unconfirmed wallet balance:",
+                    style: TextStyle(
+                        color: theme.getTheme().indicatorColor,
+                        fontSize: theme.getSmallFont(context),
+                        fontWeight: FontWeight.w300)),
+                Text(
+                    textAlign: TextAlign.right,
+                    formatDCR(atomsToDCR(unconfirmedBalance)),
+                    style: TextStyle(
+                        color: theme.getTheme().indicatorColor,
+                        fontSize: theme.getSmallFont(context),
+                        fontWeight: FontWeight.w300)),
+              ])),
+          const SizedBox(height: 3),
+          Container(
+              padding: const EdgeInsets.only(left: 324 + 22, right: 324 + 20),
+              child: Row(children: [
+                Text(
+                    textAlign: TextAlign.left,
+                    "Confirmed wallet balance:",
+                    style: TextStyle(
+                        color: theme.getTheme().indicatorColor,
+                        fontSize: theme.getSmallFont(context),
+                        fontWeight: FontWeight.w300)),
+                Text(
+                    textAlign: TextAlign.right,
+                    formatDCR(atomsToDCR(confirmedBalance)),
+                    style: TextStyle(
+                        color: theme.getTheme().indicatorColor,
+                        fontSize: theme.getSmallFont(context),
+                        fontWeight: FontWeight.w300))
+              ])),
+          const SizedBox(height: 20),
+          LoadingScreenButton(
+            onPressed: () => Navigator.of(context).pop(),
+            text: "Finish",
+          ),
+          const Expanded(child: Empty()),
+        ],
+      ),
     );
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/needs_in_channel.dart
+++ b/bruig/flutterui/bruig/lib/screens/needs_in_channel.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:bruig/components/dcr_input.dart';
 import 'package:bruig/components/buttons.dart';
-import 'package:bruig/components/info_grid.dart';
 import 'package:bruig/components/snackbars.dart';
 import 'package:bruig/models/client.dart';
 import 'package:bruig/models/notifications.dart';
@@ -10,7 +9,6 @@ import 'package:bruig/screens/startupscreen.dart';
 import 'package:flutter/material.dart';
 import 'package:golib_plugin/golib_plugin.dart';
 import 'package:golib_plugin/util.dart';
-import 'package:tuple/tuple.dart';
 import 'package:bruig/components/empty_widget.dart';
 import 'package:bruig/theme_manager.dart';
 import 'package:provider/provider.dart';
@@ -187,18 +185,14 @@ cNPr8Y+sSs2MHf6xMNBQzV4KuIlPIg==
 
   @override
   Widget build(BuildContext context) {
-    return StartupScreen(Consumer<ThemeNotifier>(
-      builder: (context, theme, child) => ListView(
-        physics: const ClampingScrollPhysics(),
-        children: [
-          const SizedBox(height: 89),
-          Center(
-            child: Text("Setting up Bison Relay",
-                style: TextStyle(
-                    color: theme.getTheme().dividerColor,
-                    fontSize: theme.getHugeFont(context),
-                    fontWeight: FontWeight.w200)),
-          ),
+    return Consumer<ThemeNotifier>(
+      builder: (context, theme, child) => StartupScreen(
+        [
+          Text("Setting up Bison Relay",
+              style: TextStyle(
+                  color: theme.getTheme().dividerColor,
+                  fontSize: theme.getHugeFont(context),
+                  fontWeight: FontWeight.w200)),
           const SizedBox(height: 20),
           Center(
             child: Text("Add Inbound Capacity",
@@ -207,7 +201,7 @@ cNPr8Y+sSs2MHf6xMNBQzV4KuIlPIg==
                     fontSize: theme.getLargeFont(context),
                     fontWeight: FontWeight.w300)),
           ),
-          const SizedBox(height: 34),
+          const SizedBox(height: 20),
           Center(
               child: SizedBox(
             width: 650,
@@ -225,26 +219,23 @@ After the channel is opened, it may take up to 6 confirmations for it to be broa
                     fontSize: theme.getMediumFont(context),
                     fontWeight: FontWeight.w300)),
           )),
-          const SizedBox(height: 21),
-          Container(
-              margin: const EdgeInsets.only(left: 324 + 22, right: 324 + 20),
-              child:
-                  Row(mainAxisAlignment: MainAxisAlignment.center, children: [
-                Text(
-                    textAlign: TextAlign.left,
-                    "Outbound Channel Capacity:",
-                    style: TextStyle(
-                        color: theme.getTheme().indicatorColor,
-                        fontSize: theme.getSmallFont(context),
-                        fontWeight: FontWeight.w300)),
-                Text(
-                    textAlign: TextAlign.right,
-                    formatDCR(atomsToDCR(maxOutAmount)),
-                    style: TextStyle(
-                        color: theme.getTheme().indicatorColor,
-                        fontSize: theme.getSmallFont(context),
-                        fontWeight: FontWeight.w300)),
-              ])),
+          const SizedBox(height: 10),
+          Row(mainAxisAlignment: MainAxisAlignment.center, children: [
+            Text(
+                textAlign: TextAlign.left,
+                "Outbound Channel Capacity:",
+                style: TextStyle(
+                    color: theme.getTheme().indicatorColor,
+                    fontSize: theme.getSmallFont(context),
+                    fontWeight: FontWeight.w300)),
+            Text(
+                textAlign: TextAlign.right,
+                formatDCR(atomsToDCR(maxOutAmount)),
+                style: TextStyle(
+                    color: theme.getTheme().indicatorColor,
+                    fontSize: theme.getSmallFont(context),
+                    fontWeight: FontWeight.w300)),
+          ]),
           const SizedBox(height: 3),
           Row(mainAxisAlignment: MainAxisAlignment.center, children: [
             Text(
@@ -296,61 +287,58 @@ After the channel is opened, it may take up to 6 confirmations for it to be broa
           ]),
           const SizedBox(height: 10),
           preventMsg == ""
-              ? Center(
-                  child: LoadingScreenButton(
+              ? Column(children: [
+                  Row(mainAxisAlignment: MainAxisAlignment.center, children: [
+                    Text("Amount",
+                        style: TextStyle(
+                            color: theme.getTheme().indicatorColor,
+                            fontSize: theme.getSmallFont(context),
+                            fontWeight: FontWeight.w300)),
+                    const SizedBox(
+                      width: 10,
+                    ),
+                    SizedBox(
+                      width: 150,
+                      child: dcrInput(controller: amountCtrl),
+                    ),
+                  ]),
+                  const SizedBox(height: 10),
+                  LoadingScreenButton(
                     empty: true,
                     onPressed:
                         showAdvanced ? hideAdvancedArea : showAdvancedArea,
                     text: showAdvanced ? "Hide Advanced" : "Show Advanced",
                   ),
-                )
-              : Empty(),
-          const SizedBox(height: 10),
-          preventMsg == ""
-              ? ListView(
-                  physics: const NeverScrollableScrollPhysics(),
-                  shrinkWrap: true,
-                  padding: const EdgeInsets.all(15.0),
-                  children: [
-                      Text("Amount",
-                          style: TextStyle(
-                              color: theme.getTheme().indicatorColor,
-                              fontSize: theme.getSmallFont(context),
-                              fontWeight: FontWeight.w300)),
-                      SizedBox(
-                        width: 150,
-                        child: dcrInput(controller: amountCtrl),
-                      ),
-                      const SizedBox(height: 50),
-                      LoadingScreenButton(
-                        onPressed: !loading ? requestRecvCapacity : null,
-                        text: "Request Inbound Channel",
-                      ),
-                      if (showAdvanced) ...[
-                        const SizedBox(height: 10),
-                        Text("LP Server Address",
-                            style: TextStyle(
-                                color: theme.getTheme().indicatorColor,
-                                fontSize: theme.getSmallFont(context),
-                                fontWeight: FontWeight.w300)),
-                        TextField(
-                          controller: serverCtrl,
-                          decoration: const InputDecoration(
-                              hintText: "https://lpd-server:port"),
-                        ),
-                        const SizedBox(height: 10),
-                        Text("LP Server Cert",
-                            style: TextStyle(
-                                color: theme.getTheme().indicatorColor,
-                                fontSize: theme.getSmallFont(context),
-                                fontWeight: FontWeight.w300)),
-                        TextField(
-                          controller: certCtrl,
-                          maxLines: null,
-                          keyboardType: TextInputType.multiline,
-                        )
-                      ]
-                    ])
+                  const SizedBox(height: 10),
+                  LoadingScreenButton(
+                    onPressed: !loading ? requestRecvCapacity : null,
+                    text: "Request Inbound Channel",
+                  ),
+                  if (showAdvanced) ...[
+                    const SizedBox(height: 10),
+                    Text("LP Server Address",
+                        style: TextStyle(
+                            color: theme.getTheme().indicatorColor,
+                            fontSize: theme.getSmallFont(context),
+                            fontWeight: FontWeight.w300)),
+                    TextField(
+                      controller: serverCtrl,
+                      decoration: const InputDecoration(
+                          hintText: "https://lpd-server:port"),
+                    ),
+                    const SizedBox(height: 10),
+                    Text("LP Server Cert",
+                        style: TextStyle(
+                            color: theme.getTheme().indicatorColor,
+                            fontSize: theme.getSmallFont(context),
+                            fontWeight: FontWeight.w300)),
+                    TextField(
+                      controller: certCtrl,
+                      maxLines: null,
+                      keyboardType: TextInputType.multiline,
+                    )
+                  ]
+                ])
               : Column(children: [
                   const SizedBox(height: 30),
                   Text(
@@ -358,14 +346,13 @@ After the channel is opened, it may take up to 6 confirmations for it to be broa
                     style: TextStyle(color: theme.getTheme().dividerColor),
                   )
                 ]),
-          Center(
-            child: LoadingScreenButton(
-              onPressed: () => Navigator.of(context).pop(),
-              text: "Skip",
-            ),
-          )
+          const SizedBox(height: 10),
+          LoadingScreenButton(
+            onPressed: () => Navigator.of(context).pop(),
+            text: "Skip",
+          ),
         ],
       ),
-    ));
+    );
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/needs_in_channel.dart
+++ b/bruig/flutterui/bruig/lib/screens/needs_in_channel.dart
@@ -9,7 +9,6 @@ import 'package:bruig/screens/startupscreen.dart';
 import 'package:flutter/material.dart';
 import 'package:golib_plugin/golib_plugin.dart';
 import 'package:golib_plugin/util.dart';
-import 'package:bruig/components/empty_widget.dart';
 import 'package:bruig/theme_manager.dart';
 import 'package:provider/provider.dart';
 

--- a/bruig/flutterui/bruig/lib/screens/needs_out_channel.dart
+++ b/bruig/flutterui/bruig/lib/screens/needs_out_channel.dart
@@ -179,11 +179,9 @@ open channels to other LN nodes.''';
 
   @override
   Widget build(BuildContext context) {
-    return StartupScreen(Consumer<ThemeNotifier>(
-      builder: (context, theme, child) => ListView(
-        physics: const ClampingScrollPhysics(),
-        children: [
-          const SizedBox(height: 89),
+    return Consumer<ThemeNotifier>(
+      builder: (context, theme, child) => StartupScreen(
+        [
           Center(
             child: Text("Setting up Bison Relay",
                 style: TextStyle(
@@ -199,7 +197,7 @@ open channels to other LN nodes.''';
                     fontSize: theme.getLargeFont(context),
                     fontWeight: FontWeight.w300)),
           ),
-          const SizedBox(height: 34),
+          const SizedBox(height: 20),
           Center(
             child: SizedBox(
                 width: 650,
@@ -217,26 +215,23 @@ Note that Lightning Network channels require managing off-chain data, and as suc
                       fontWeight: FontWeight.w300),
                 )),
           ),
-          const SizedBox(height: 21),
-          Container(
-              margin: const EdgeInsets.only(left: 324 + 22, right: 324 + 20),
-              child:
-                  Row(mainAxisAlignment: MainAxisAlignment.center, children: [
-                Text(
-                    textAlign: TextAlign.left,
-                    "Wallet Balance:",
-                    style: TextStyle(
-                        color: theme.getTheme().indicatorColor,
-                        fontSize: theme.getSmallFont(context),
-                        fontWeight: FontWeight.w300)),
-                Text(
-                    textAlign: TextAlign.right,
-                    formatDCR(atomsToDCR(walletBalance)),
-                    style: TextStyle(
-                        color: theme.getTheme().indicatorColor,
-                        fontSize: theme.getSmallFont(context),
-                        fontWeight: FontWeight.w300)),
-              ])),
+          const SizedBox(height: 10),
+          Row(mainAxisAlignment: MainAxisAlignment.center, children: [
+            Text(
+                textAlign: TextAlign.left,
+                "Wallet Balance:",
+                style: TextStyle(
+                    color: theme.getTheme().indicatorColor,
+                    fontSize: theme.getSmallFont(context),
+                    fontWeight: FontWeight.w300)),
+            Text(
+                textAlign: TextAlign.right,
+                formatDCR(atomsToDCR(walletBalance)),
+                style: TextStyle(
+                    color: theme.getTheme().indicatorColor,
+                    fontSize: theme.getSmallFont(context),
+                    fontWeight: FontWeight.w300)),
+          ]),
           const SizedBox(height: 3),
           Row(mainAxisAlignment: MainAxisAlignment.center, children: [
             Text(
@@ -288,70 +283,68 @@ Note that Lightning Network channels require managing off-chain data, and as suc
           ]),
           const SizedBox(height: 10),
           preventMsg == ""
-              ? Center(
-                  child: LoadingScreenButton(
+              ? Column(children: [
+                  Row(mainAxisAlignment: MainAxisAlignment.center, children: [
+                    Text("Amount",
+                        style: TextStyle(
+                            color: theme.getTheme().indicatorColor,
+                            fontSize: theme.getSmallFont(context),
+                            fontWeight: FontWeight.w300)),
+                    const SizedBox(
+                      width: 10,
+                    ),
+                    SizedBox(
+                      width: 150,
+                      child: dcrInput(controller: amountCtrl),
+                    )
+                  ]),
+                  const SizedBox(height: 10),
+                  LoadingScreenButton(
                     empty: true,
                     onPressed:
                         showAdvanced ? hideAdvancedArea : showAdvancedArea,
                     text: showAdvanced ? "Hide Advanced" : "Show Advanced",
                   ),
-                )
-              : const Empty(),
-          const SizedBox(height: 10),
-          preventMsg == ""
-              ? ListView(
-                  physics: const NeverScrollableScrollPhysics(),
-                  shrinkWrap: true,
-                  padding: const EdgeInsets.all(15.0),
-                  children: <Widget>[
-                      SimpleInfoGrid([
-                        Tuple2(
-                            Text("Amount",
-                                style: TextStyle(
-                                    color: theme.getTheme().indicatorColor,
-                                    fontSize: theme.getSmallFont(context),
-                                    fontWeight: FontWeight.w300)),
-                            SizedBox(
-                              width: 150,
-                              child: dcrInput(controller: amountCtrl),
-                            )),
-                        Tuple2(
-                            const SizedBox(height: 50),
-                            LoadingScreenButton(
-                              onPressed: !loading ? openChannel : null,
-                              text: "Request Outbound Channel",
-                            ))
-                      ]),
-                      showAdvanced
-                          ? SimpleInfoGrid([
-                              Tuple2(
-                                  Text("Peer ID and Address",
-                                      style: TextStyle(
-                                          color:
-                                              theme.getTheme().indicatorColor,
-                                          fontSize: theme.getSmallFont(context),
-                                          fontWeight: FontWeight.w300)),
-                                  TextField(
-                                    controller: peerCtrl,
-                                    decoration: const InputDecoration(
-                                        hintText: "node-pub-key@addr:port"),
-                                  )),
-                            ])
-                          : const Empty(),
-                    ])
-              : Column(children: [
-                  const SizedBox(height: 30),
-                  Text(preventMsg,
-                      style: TextStyle(color: theme.getTheme().dividerColor))
-                ]),
-          Center(
-            child: LoadingScreenButton(
-              onPressed: () => Navigator.of(context).pop(),
-              text: "Skip",
-            ),
-          )
+                  const SizedBox(height: 10),
+                  LoadingScreenButton(
+                    onPressed: !loading ? openChannel : null,
+                    text: "Request Outbound Channel",
+                  ),
+                  showAdvanced
+                      ? Column(children: [
+                          const SizedBox(height: 10),
+                          Row(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                Text("Peer ID and Address",
+                                    style: TextStyle(
+                                        color: theme.getTheme().indicatorColor,
+                                        fontSize: theme.getSmallFont(context),
+                                        fontWeight: FontWeight.w300)),
+                                const SizedBox(width: 10),
+                                Expanded(
+                                    child: TextField(
+                                  style: TextStyle(
+                                      color: theme.getTheme().focusColor,
+                                      fontSize: theme.getSmallFont(context),
+                                      fontWeight: FontWeight.w300),
+                                  controller: peerCtrl,
+                                  decoration: const InputDecoration(
+                                      hintText: "node-pub-key@addr:port"),
+                                ))
+                              ]),
+                          const SizedBox(height: 10),
+                        ])
+                      : const SizedBox(height: 10),
+                ])
+              : Text(preventMsg,
+                  style: TextStyle(color: theme.getTheme().dividerColor)),
+          LoadingScreenButton(
+            onPressed: () => Navigator.of(context).pop(),
+            text: "Skip",
+          ),
         ],
       ),
-    ));
+    );
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/needs_out_channel.dart
+++ b/bruig/flutterui/bruig/lib/screens/needs_out_channel.dart
@@ -2,8 +2,6 @@ import 'dart:async';
 
 import 'package:bruig/components/buttons.dart';
 import 'package:bruig/components/dcr_input.dart';
-import 'package:bruig/components/empty_widget.dart';
-import 'package:bruig/components/info_grid.dart';
 import 'package:bruig/components/snackbars.dart';
 import 'package:bruig/models/client.dart';
 import 'package:bruig/models/notifications.dart';
@@ -11,7 +9,6 @@ import 'package:bruig/screens/startupscreen.dart';
 import 'package:flutter/material.dart';
 import 'package:golib_plugin/golib_plugin.dart';
 import 'package:golib_plugin/util.dart';
-import 'package:tuple/tuple.dart';
 import 'package:bruig/theme_manager.dart';
 import 'package:provider/provider.dart';
 

--- a/bruig/flutterui/bruig/lib/screens/newconfig/delete_old_wallet.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/delete_old_wallet.dart
@@ -39,10 +39,8 @@ class _DeleteOldWalletPageState extends State<DeleteOldWalletPage> {
 
   @override
   Widget build(BuildContext context) {
-    return StartupScreen(Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => Column(children: [
-              const SetupScreenAbountButton(),
-              const SizedBox(height: 39),
+    return Consumer<ThemeNotifier>(
+        builder: (context, theme, _) => StartupScreen(Column(children: [
               Text("Remove old wallet",
                   style: TextStyle(
                       color: theme.getTheme().dividerColor,

--- a/bruig/flutterui/bruig/lib/screens/newconfig/delete_old_wallet.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/delete_old_wallet.dart
@@ -40,7 +40,7 @@ class _DeleteOldWalletPageState extends State<DeleteOldWalletPage> {
   @override
   Widget build(BuildContext context) {
     return Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => StartupScreen(Column(children: [
+        builder: (context, theme, _) => StartupScreen([
               Text("Remove old wallet",
                   style: TextStyle(
                       color: theme.getTheme().dividerColor,
@@ -88,6 +88,6 @@ class _DeleteOldWalletPageState extends State<DeleteOldWalletPage> {
                           const SizedBox(width: 10),
                         ])))
               ]),
-            ])));
+            ]));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/newconfig/initializing.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/initializing.dart
@@ -36,10 +36,8 @@ class _InitializingNewConfPageState extends State<InitializingNewConfPage> {
 
   @override
   Widget build(BuildContext context) {
-    return StartupScreen(Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => Column(children: [
-              const SetupScreenAbountButton(),
-              const SizedBox(height: 39),
+    return Consumer<ThemeNotifier>(
+        builder: (context, theme, _) => StartupScreen(Column(children: [
               Text("Setting up Bison Relay",
                   style: TextStyle(
                       color: theme.getTheme().dividerColor,

--- a/bruig/flutterui/bruig/lib/screens/newconfig/initializing.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/initializing.dart
@@ -1,4 +1,3 @@
-import 'package:bruig/components/buttons.dart';
 import 'package:bruig/models/newconfig.dart';
 import 'package:bruig/screens/startupscreen.dart';
 import 'package:flutter/material.dart';

--- a/bruig/flutterui/bruig/lib/screens/newconfig/initializing.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/initializing.dart
@@ -37,13 +37,13 @@ class _InitializingNewConfPageState extends State<InitializingNewConfPage> {
   @override
   Widget build(BuildContext context) {
     return Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => StartupScreen(Column(children: [
+        builder: (context, theme, _) => StartupScreen([
               Text("Setting up Bison Relay",
                   style: TextStyle(
                       color: theme.getTheme().dividerColor,
                       fontSize: theme.getHugeFont(context),
                       fontWeight: FontWeight.w200)),
               const SizedBox(height: 20),
-            ])));
+            ]));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/newconfig/ln_choice.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/ln_choice.dart
@@ -29,7 +29,7 @@ class LNChoicePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => StartupScreen(Column(children: [
+        builder: (context, theme, _) => StartupScreen([
               Text("Setting up Bison Relay",
                   style: TextStyle(
                       color: theme.getTheme().dividerColor,
@@ -61,6 +61,6 @@ class LNChoicePage extends StatelessWidget {
                       style: TextStyle(color: theme.getTheme().dividerColor)),
                 )
               ])
-            ])));
+            ]));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/newconfig/ln_choice.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/ln_choice.dart
@@ -28,10 +28,8 @@ class LNChoicePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return StartupScreen(Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => Column(children: [
-              const SetupScreenAbountButton(),
-              const Expanded(child: Empty()),
+    return Consumer<ThemeNotifier>(
+        builder: (context, theme, _) => StartupScreen(Column(children: [
               Text("Setting up Bison Relay",
                   style: TextStyle(
                       color: theme.getTheme().dividerColor,

--- a/bruig/flutterui/bruig/lib/screens/newconfig/ln_choice_external.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/ln_choice_external.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:bruig/components/empty_widget.dart';
 import 'package:bruig/components/snackbars.dart';
 import 'package:bruig/components/buttons.dart';
 import 'package:bruig/models/newconfig.dart';

--- a/bruig/flutterui/bruig/lib/screens/newconfig/ln_choice_external.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/ln_choice_external.dart
@@ -80,7 +80,7 @@ class _LNExternalWalletPageState extends State<LNExternalWalletPage> {
   @override
   Widget build(BuildContext context) {
     return Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => StartupScreen(Column(children: [
+        builder: (context, theme, _) => StartupScreen([
               Text("Setting up Bison Relay",
                   style: TextStyle(
                       color: theme.getTheme().dividerColor,
@@ -199,6 +199,6 @@ class _LNExternalWalletPageState extends State<LNExternalWalletPage> {
                               : const SizedBox(width: 25),
                         ]))),
               ])
-            ])));
+            ]));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/newconfig/ln_choice_external.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/ln_choice_external.dart
@@ -79,10 +79,8 @@ class _LNExternalWalletPageState extends State<LNExternalWalletPage> {
 
   @override
   Widget build(BuildContext context) {
-    return StartupScreen(Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => Column(children: [
-              const SetupScreenAbountButton(),
-              const SizedBox(height: 39),
+    return Consumer<ThemeNotifier>(
+        builder: (context, theme, _) => StartupScreen(Column(children: [
               Text("Setting up Bison Relay",
                   style: TextStyle(
                       color: theme.getTheme().dividerColor,

--- a/bruig/flutterui/bruig/lib/screens/newconfig/ln_choice_internal.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/ln_choice_internal.dart
@@ -69,10 +69,8 @@ class _LNInternalWalletPageState extends State<LNInternalWalletPage> {
   Widget build(BuildContext context) {
     bool isScreenSmall = MediaQuery.of(context).size.width <= 500;
 
-    return StartupScreen(Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => Column(children: [
-              const SetupScreenAbountButton(),
-              SizedBox(height: isScreenSmall ? 5 : 39),
+    return Consumer<ThemeNotifier>(
+        builder: (context, theme, _) => StartupScreen(Column(children: [
               Text("Setting up Bison Relay",
                   style: TextStyle(
                       color: theme.getTheme().dividerColor,

--- a/bruig/flutterui/bruig/lib/screens/newconfig/ln_choice_internal.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/ln_choice_internal.dart
@@ -70,7 +70,7 @@ class _LNInternalWalletPageState extends State<LNInternalWalletPage> {
     bool isScreenSmall = MediaQuery.of(context).size.width <= 500;
 
     return Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => StartupScreen(Column(children: [
+        builder: (context, theme, _) => StartupScreen([
               Text("Setting up Bison Relay",
                   style: TextStyle(
                       color: theme.getTheme().dividerColor,
@@ -186,6 +186,6 @@ class _LNInternalWalletPageState extends State<LNInternalWalletPage> {
                       )
                     : const Empty(),
               ])
-            ])));
+            ]));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/newconfig/ln_wallet_seed.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/ln_wallet_seed.dart
@@ -25,46 +25,44 @@ class NewLNWalletSeedPage extends StatelessWidget {
     var seedWords = newconf.newWalletSeed.split(' ');
 
     return Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => StartupScreen(
-              Column(children: [
-                Text("Setting up Bison Relay",
-                    style: TextStyle(
-                        color: theme.getTheme().dividerColor,
-                        fontSize: theme.getHugeFont(context),
-                        fontWeight: FontWeight.w200)),
-                const SizedBox(height: 20),
-                Text("Confirm New Wallet Seed",
-                    style: TextStyle(
-                        color: theme.getTheme().focusColor,
-                        fontSize: theme.getLargeFont(context),
-                        fontWeight: FontWeight.w300)),
-                const SizedBox(height: 34),
-                Center(
-                  child: SizedBox(
-                      width: 519,
-                      child: Wrap(spacing: 5, runSpacing: 5, children: [
-                        for (var i in seedWords)
-                          i != ""
-                              ? Container(
-                                  padding: const EdgeInsets.only(
-                                      left: 8, top: 3, right: 8, bottom: 3),
-                                  color: theme.getTheme().backgroundColor,
-                                  child: Text(i,
-                                      style: TextStyle(
-                                          color: theme.getTheme().dividerColor,
-                                          fontSize:
-                                              theme.getMediumFont(context),
-                                          fontWeight: FontWeight.w300)))
-                              : const Empty()
-                      ])),
-                ),
-                const SizedBox(height: 10),
-                TextButton(
-                  onPressed: () => copySeedToClipboard(context),
-                  child: Text("Copy to Clipboard",
-                      style: TextStyle(color: theme.getTheme().dividerColor)),
-                ),
-                /*   XXX NEED TO FIGURE OUT LISTVIEW within a row FOR SEED WORD BUBBLES
+      builder: (context, theme, _) => StartupScreen([
+        Text("Setting up Bison Relay",
+            style: TextStyle(
+                color: theme.getTheme().dividerColor,
+                fontSize: theme.getHugeFont(context),
+                fontWeight: FontWeight.w200)),
+        const SizedBox(height: 20),
+        Text("Confirm New Wallet Seed",
+            style: TextStyle(
+                color: theme.getTheme().focusColor,
+                fontSize: theme.getLargeFont(context),
+                fontWeight: FontWeight.w300)),
+        const SizedBox(height: 34),
+        Center(
+          child: SizedBox(
+              width: 519,
+              child: Wrap(spacing: 5, runSpacing: 5, children: [
+                for (var i in seedWords)
+                  i != ""
+                      ? Container(
+                          padding: const EdgeInsets.only(
+                              left: 8, top: 3, right: 8, bottom: 3),
+                          color: theme.getTheme().backgroundColor,
+                          child: Text(i,
+                              style: TextStyle(
+                                  color: theme.getTheme().dividerColor,
+                                  fontSize: theme.getMediumFont(context),
+                                  fontWeight: FontWeight.w300)))
+                      : const Empty()
+              ])),
+        ),
+        const SizedBox(height: 10),
+        TextButton(
+          onPressed: () => copySeedToClipboard(context),
+          child: Text("Copy to Clipboard",
+              style: TextStyle(color: theme.getTheme().dividerColor)),
+        ),
+        /*   XXX NEED TO FIGURE OUT LISTVIEW within a row FOR SEED WORD BUBBLES
               Expanded(
                   child: ListView.builder(
                 shrinkWrap: true,
@@ -81,13 +79,13 @@ class NewLNWalletSeedPage extends StatelessWidget {
                             fontWeight: FontWeight.w300))),
               )),
               */
-                const SizedBox(height: 34),
-                LoadingScreenButton(
-                  onPressed: done,
-                  text: "I have copied the seed",
-                ),
-                const Expanded(child: Empty()),
-              ]),
-            ));
+        const SizedBox(height: 34),
+        LoadingScreenButton(
+          onPressed: done,
+          text: "I have copied the seed",
+        ),
+        const Expanded(child: Empty()),
+      ]),
+    );
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/newconfig/ln_wallet_seed.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/ln_wallet_seed.dart
@@ -24,47 +24,47 @@ class NewLNWalletSeedPage extends StatelessWidget {
 
     var seedWords = newconf.newWalletSeed.split(' ');
 
-    return StartupScreen(Consumer<ThemeNotifier>(
-      builder: (context, theme, _) => Column(children: [
-        const SetupScreenAbountButton(),
-        const SizedBox(height: 39),
-        Text("Setting up Bison Relay",
-            style: TextStyle(
-                color: theme.getTheme().dividerColor,
-                fontSize: theme.getHugeFont(context),
-                fontWeight: FontWeight.w200)),
-        const SizedBox(height: 20),
-        Text("Confirm New Wallet Seed",
-            style: TextStyle(
-                color: theme.getTheme().focusColor,
-                fontSize: theme.getLargeFont(context),
-                fontWeight: FontWeight.w300)),
-        const SizedBox(height: 34),
-        Center(
-          child: SizedBox(
-              width: 519,
-              child: Wrap(spacing: 5, runSpacing: 5, children: [
-                for (var i in seedWords)
-                  i != ""
-                      ? Container(
-                          padding: const EdgeInsets.only(
-                              left: 8, top: 3, right: 8, bottom: 3),
-                          color: theme.getTheme().backgroundColor,
-                          child: Text(i,
-                              style: TextStyle(
-                                  color: theme.getTheme().dividerColor,
-                                  fontSize: theme.getMediumFont(context),
-                                  fontWeight: FontWeight.w300)))
-                      : const Empty()
-              ])),
-        ),
-        const SizedBox(height: 10),
-        TextButton(
-          onPressed: () => copySeedToClipboard(context),
-          child: Text("Copy to Clipboard",
-              style: TextStyle(color: theme.getTheme().dividerColor)),
-        ),
-        /*   XXX NEED TO FIGURE OUT LISTVIEW within a row FOR SEED WORD BUBBLES
+    return Consumer<ThemeNotifier>(
+        builder: (context, theme, _) => StartupScreen(
+              Column(children: [
+                Text("Setting up Bison Relay",
+                    style: TextStyle(
+                        color: theme.getTheme().dividerColor,
+                        fontSize: theme.getHugeFont(context),
+                        fontWeight: FontWeight.w200)),
+                const SizedBox(height: 20),
+                Text("Confirm New Wallet Seed",
+                    style: TextStyle(
+                        color: theme.getTheme().focusColor,
+                        fontSize: theme.getLargeFont(context),
+                        fontWeight: FontWeight.w300)),
+                const SizedBox(height: 34),
+                Center(
+                  child: SizedBox(
+                      width: 519,
+                      child: Wrap(spacing: 5, runSpacing: 5, children: [
+                        for (var i in seedWords)
+                          i != ""
+                              ? Container(
+                                  padding: const EdgeInsets.only(
+                                      left: 8, top: 3, right: 8, bottom: 3),
+                                  color: theme.getTheme().backgroundColor,
+                                  child: Text(i,
+                                      style: TextStyle(
+                                          color: theme.getTheme().dividerColor,
+                                          fontSize:
+                                              theme.getMediumFont(context),
+                                          fontWeight: FontWeight.w300)))
+                              : const Empty()
+                      ])),
+                ),
+                const SizedBox(height: 10),
+                TextButton(
+                  onPressed: () => copySeedToClipboard(context),
+                  child: Text("Copy to Clipboard",
+                      style: TextStyle(color: theme.getTheme().dividerColor)),
+                ),
+                /*   XXX NEED TO FIGURE OUT LISTVIEW within a row FOR SEED WORD BUBBLES
               Expanded(
                   child: ListView.builder(
                 shrinkWrap: true,
@@ -81,13 +81,13 @@ class NewLNWalletSeedPage extends StatelessWidget {
                             fontWeight: FontWeight.w300))),
               )),
               */
-        const SizedBox(height: 34),
-        LoadingScreenButton(
-          onPressed: done,
-          text: "I have copied the seed",
-        ),
-        const Expanded(child: Empty()),
-      ]),
-    ));
+                const SizedBox(height: 34),
+                LoadingScreenButton(
+                  onPressed: done,
+                  text: "I have copied the seed",
+                ),
+                const Expanded(child: Empty()),
+              ]),
+            ));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/newconfig/ln_wallet_seed_confirm.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/ln_wallet_seed_confirm.dart
@@ -54,46 +54,46 @@ class _ConfirmLNWalletSeedPageState extends State<ConfirmLNWalletSeedPage> {
 
     var confirmSeedWords = widget.newconf.confirmSeedWords;
 
-    return StartupScreen(Consumer<ThemeNotifier>(
-      builder: (context, theme, _) => Column(children: [
-        const SetupScreenAbountButton(),
-        const SizedBox(height: 39),
-        Text("Setting up Bison Relay",
-            style: TextStyle(
-                color: theme.getTheme().dividerColor,
-                fontSize: theme.getHugeFont(context),
-                fontWeight: FontWeight.w200)),
-        const SizedBox(height: 20),
-        Text("Confirm New Wallet Seed",
-            style: TextStyle(
-                color: theme.getTheme().focusColor,
-                fontSize: theme.getLargeFont(context),
-                fontWeight: FontWeight.w300)),
-        const SizedBox(height: 34),
-        AnimatedOpacity(
-          opacity: _visible ? 1.0 : 0.0,
-          duration: const Duration(milliseconds: 500),
-          child: currentQuestion < confirmSeedWords.length
-              ? !answerWrong
-                  ? QuestionArea(confirmSeedWords[currentQuestion], checkAnswer)
-                  : IncorrectArea(goBack)
-              : Column(children: [
-                  Text("Seed Confirmed",
-                      style: TextStyle(
-                          color: theme.getTheme().dividerColor,
-                          fontSize: theme.getLargeFont(context),
-                          fontWeight: FontWeight.w200)),
-                  const SizedBox(height: 20),
-                  Center(
-                      child: LoadingScreenButton(
-                    onPressed: done,
-                    text: "Continue",
-                  ))
-                ]),
-        ),
-        const SizedBox(height: 34),
-      ]),
-    ));
+    return Consumer<ThemeNotifier>(
+        builder: (context, theme, _) => StartupScreen(
+              Column(children: [
+                Text("Setting up Bison Relay",
+                    style: TextStyle(
+                        color: theme.getTheme().dividerColor,
+                        fontSize: theme.getHugeFont(context),
+                        fontWeight: FontWeight.w200)),
+                const SizedBox(height: 20),
+                Text("Confirm New Wallet Seed",
+                    style: TextStyle(
+                        color: theme.getTheme().focusColor,
+                        fontSize: theme.getLargeFont(context),
+                        fontWeight: FontWeight.w300)),
+                const SizedBox(height: 34),
+                AnimatedOpacity(
+                  opacity: _visible ? 1.0 : 0.0,
+                  duration: const Duration(milliseconds: 500),
+                  child: currentQuestion < confirmSeedWords.length
+                      ? !answerWrong
+                          ? QuestionArea(
+                              confirmSeedWords[currentQuestion], checkAnswer)
+                          : IncorrectArea(goBack)
+                      : Column(children: [
+                          Text("Seed Confirmed",
+                              style: TextStyle(
+                                  color: theme.getTheme().dividerColor,
+                                  fontSize: theme.getLargeFont(context),
+                                  fontWeight: FontWeight.w200)),
+                          const SizedBox(height: 20),
+                          Center(
+                              child: LoadingScreenButton(
+                            onPressed: done,
+                            text: "Continue",
+                          ))
+                        ]),
+                ),
+                const SizedBox(height: 34),
+              ]),
+            ));
   }
 }
 

--- a/bruig/flutterui/bruig/lib/screens/newconfig/ln_wallet_seed_confirm.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/ln_wallet_seed_confirm.dart
@@ -55,45 +55,43 @@ class _ConfirmLNWalletSeedPageState extends State<ConfirmLNWalletSeedPage> {
     var confirmSeedWords = widget.newconf.confirmSeedWords;
 
     return Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => StartupScreen(
-              Column(children: [
-                Text("Setting up Bison Relay",
-                    style: TextStyle(
-                        color: theme.getTheme().dividerColor,
-                        fontSize: theme.getHugeFont(context),
-                        fontWeight: FontWeight.w200)),
-                const SizedBox(height: 20),
-                Text("Confirm New Wallet Seed",
-                    style: TextStyle(
-                        color: theme.getTheme().focusColor,
-                        fontSize: theme.getLargeFont(context),
-                        fontWeight: FontWeight.w300)),
-                const SizedBox(height: 34),
-                AnimatedOpacity(
-                  opacity: _visible ? 1.0 : 0.0,
-                  duration: const Duration(milliseconds: 500),
-                  child: currentQuestion < confirmSeedWords.length
-                      ? !answerWrong
-                          ? QuestionArea(
-                              confirmSeedWords[currentQuestion], checkAnswer)
-                          : IncorrectArea(goBack)
-                      : Column(children: [
-                          Text("Seed Confirmed",
-                              style: TextStyle(
-                                  color: theme.getTheme().dividerColor,
-                                  fontSize: theme.getLargeFont(context),
-                                  fontWeight: FontWeight.w200)),
-                          const SizedBox(height: 20),
-                          Center(
-                              child: LoadingScreenButton(
-                            onPressed: done,
-                            text: "Continue",
-                          ))
-                        ]),
-                ),
-                const SizedBox(height: 34),
-              ]),
-            ));
+      builder: (context, theme, _) => StartupScreen([
+        Text("Setting up Bison Relay",
+            style: TextStyle(
+                color: theme.getTheme().dividerColor,
+                fontSize: theme.getHugeFont(context),
+                fontWeight: FontWeight.w200)),
+        const SizedBox(height: 20),
+        Text("Confirm New Wallet Seed",
+            style: TextStyle(
+                color: theme.getTheme().focusColor,
+                fontSize: theme.getLargeFont(context),
+                fontWeight: FontWeight.w300)),
+        const SizedBox(height: 34),
+        AnimatedOpacity(
+          opacity: _visible ? 1.0 : 0.0,
+          duration: const Duration(milliseconds: 500),
+          child: currentQuestion < confirmSeedWords.length
+              ? !answerWrong
+                  ? QuestionArea(confirmSeedWords[currentQuestion], checkAnswer)
+                  : IncorrectArea(goBack)
+              : Column(children: [
+                  Text("Seed Confirmed",
+                      style: TextStyle(
+                          color: theme.getTheme().dividerColor,
+                          fontSize: theme.getLargeFont(context),
+                          fontWeight: FontWeight.w200)),
+                  const SizedBox(height: 20),
+                  Center(
+                      child: LoadingScreenButton(
+                    onPressed: done,
+                    text: "Continue",
+                  ))
+                ]),
+        ),
+        const SizedBox(height: 34),
+      ]),
+    );
   }
 }
 

--- a/bruig/flutterui/bruig/lib/screens/newconfig/move_old_version.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/move_old_version.dart
@@ -58,10 +58,8 @@ class _MoveOldVersionWalletPageState extends State<MoveOldVersionWalletPage> {
 
   @override
   Widget build(BuildContext context) {
-    return StartupScreen(Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => Column(children: [
-              const SetupScreenAbountButton(),
-              const SizedBox(height: 39),
+    return Consumer<ThemeNotifier>(
+        builder: (context, theme, _) => StartupScreen(Column(children: [
               unableToMove
                   ? Column(children: [
                       Text("Move old wallet",

--- a/bruig/flutterui/bruig/lib/screens/newconfig/move_old_version.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/move_old_version.dart
@@ -59,7 +59,7 @@ class _MoveOldVersionWalletPageState extends State<MoveOldVersionWalletPage> {
   @override
   Widget build(BuildContext context) {
     return Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => StartupScreen(Column(children: [
+        builder: (context, theme, _) => StartupScreen([
               unableToMove
                   ? Column(children: [
                       Text("Move old wallet",
@@ -142,6 +142,6 @@ class _MoveOldVersionWalletPageState extends State<MoveOldVersionWalletPage> {
                                 ])))
                       ]),
                     ])
-            ])));
+            ]));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/newconfig/network_choice.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/network_choice.dart
@@ -24,10 +24,8 @@ class NetworkChoicePage extends StatelessWidget {
   Widget build(BuildContext context) {
     bool isScreenSmall = MediaQuery.of(context).size.width <= 500;
 
-    return StartupScreen(Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => Column(children: [
-              const SetupScreenAbountButton(),
-              const Expanded(child: Empty()),
+    return Consumer<ThemeNotifier>(
+        builder: (context, theme, _) => StartupScreen(Column(children: [
               Text("Setting up Bison Relay",
                   style: TextStyle(
                       color: theme.getTheme().dividerColor,

--- a/bruig/flutterui/bruig/lib/screens/newconfig/network_choice.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/network_choice.dart
@@ -25,7 +25,7 @@ class NetworkChoicePage extends StatelessWidget {
     bool isScreenSmall = MediaQuery.of(context).size.width <= 500;
 
     return Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => StartupScreen(Column(children: [
+        builder: (context, theme, _) => StartupScreen([
               Text("Setting up Bison Relay",
                   style: TextStyle(
                       color: theme.getTheme().dividerColor,
@@ -72,6 +72,6 @@ class NetworkChoicePage extends StatelessWidget {
                       style: TextStyle(color: theme.getTheme().dividerColor)),
                 )
               ])
-            ])));
+            ]));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/newconfig/restore_wallet.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/restore_wallet.dart
@@ -68,10 +68,8 @@ class _RestoreWalletPageState extends State<RestoreWalletPage> {
 
   @override
   Widget build(BuildContext context) {
-    return StartupScreen(Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => Column(children: [
-              const SetupScreenAbountButton(),
-              const SizedBox(height: 39),
+    return Consumer<ThemeNotifier>(
+        builder: (context, theme, _) => StartupScreen(Column(children: [
               Text("Restoring wallet",
                   style: TextStyle(
                       color: theme.getTheme().dividerColor,

--- a/bruig/flutterui/bruig/lib/screens/newconfig/restore_wallet.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/restore_wallet.dart
@@ -69,7 +69,7 @@ class _RestoreWalletPageState extends State<RestoreWalletPage> {
   @override
   Widget build(BuildContext context) {
     return Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => StartupScreen(Column(children: [
+        builder: (context, theme, _) => StartupScreen([
               Text("Restoring wallet",
                   style: TextStyle(
                       color: theme.getTheme().dividerColor,
@@ -132,6 +132,6 @@ class _RestoreWalletPageState extends State<RestoreWalletPage> {
                       style: TextStyle(color: theme.getTheme().dividerColor)),
                 )
               ])
-            ])));
+            ]));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/newconfig/server.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/server.dart
@@ -55,8 +55,8 @@ class _ServerPageState extends State<ServerPage> {
 
   @override
   Widget build(BuildContext context) {
-    return StartupScreen(Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => Column(children: [
+    return Consumer<ThemeNotifier>(
+        builder: (context, theme, _) => StartupScreen([
               Text("Setting up Bison Relay",
                   style: TextStyle(
                       color: theme.getTheme().dividerColor,
@@ -95,6 +95,6 @@ class _ServerPageState extends State<ServerPage> {
                 text: "Connect",
               ),
               const Expanded(child: Empty()),
-            ])));
+            ]));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/newconfig/server.dart
+++ b/bruig/flutterui/bruig/lib/screens/newconfig/server.dart
@@ -57,8 +57,6 @@ class _ServerPageState extends State<ServerPage> {
   Widget build(BuildContext context) {
     return StartupScreen(Consumer<ThemeNotifier>(
         builder: (context, theme, _) => Column(children: [
-              const SetupScreenAbountButton(),
-              const SizedBox(height: 39),
               Text("Setting up Bison Relay",
                   style: TextStyle(
                       color: theme.getTheme().dividerColor,

--- a/bruig/flutterui/bruig/lib/screens/onboarding.dart
+++ b/bruig/flutterui/bruig/lib/screens/onboarding.dart
@@ -337,7 +337,7 @@ Cancelling onboarding means the wallet setup, including obtaining on-chain funds
       ];
     }
 
-    return StartupScreen(Column(children: [
+    return StartupScreen([
       Row(children: [
         IconButton(
             alignment: Alignment.topLeft,
@@ -357,6 +357,6 @@ Cancelling onboarding means the wallet setup, including obtaining on-chain funds
                   fontWeight: FontWeight.w200))),
       const SizedBox(height: 20),
       ...children,
-    ]));
+    ]);
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/settings.dart
+++ b/bruig/flutterui/bruig/lib/screens/settings.dart
@@ -512,17 +512,8 @@ class AccountSettingsScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     var theme = Theme.of(context);
-    var backgroundColor = theme.backgroundColor;
     var textColor = theme.focusColor;
-    var canvasColor = theme.canvasColor;
 
-    var avatarColor = colorFromNick(client.nick);
-    var darkTextColor = theme.indicatorColor;
-    var hightLightTextColor = theme.dividerColor; // NAME TEXT COLOR
-    var avatarTextColor =
-        ThemeData.estimateBrightnessForColor(avatarColor) == Brightness.dark
-            ? hightLightTextColor
-            : darkTextColor;
     return Consumer<ThemeNotifier>(
         builder: (context, theme, _) => ListView(children: [
               ListTile(

--- a/bruig/flutterui/bruig/lib/screens/shutdown.dart
+++ b/bruig/flutterui/bruig/lib/screens/shutdown.dart
@@ -68,22 +68,18 @@ class _ShutdownScreenState extends State<ShutdownScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-        body: StartupScreen(Consumer<ThemeNotifier>(
-            builder: (context, theme, child) => Container(
-                padding: const EdgeInsets.all(10),
-                child: Column(children: [
-                  const SizedBox(height: 89),
-                  Text("Shutting Down Bison Relay",
-                      style: TextStyle(
-                          color: theme.getTheme().dividerColor,
-                          fontSize: theme.getHugeFont(context),
-                          fontWeight: FontWeight.w200)),
-                  clientStopErr != null ? Text(clientStopErr!) : const Empty(),
-                  const SizedBox(height: 20),
-                  const Divider(),
-                  const SizedBox(height: 20),
-                  Expanded(child: LogLines(widget.log))
-                ])))));
+    return Consumer<ThemeNotifier>(
+        builder: (context, theme, child) => StartupScreen([
+              Text("Shutting Down Bison Relay",
+                  style: TextStyle(
+                      color: theme.getTheme().dividerColor,
+                      fontSize: theme.getHugeFont(context),
+                      fontWeight: FontWeight.w200)),
+              clientStopErr != null ? Text(clientStopErr!) : const Empty(),
+              const SizedBox(height: 20),
+              const Divider(),
+              const SizedBox(height: 20),
+              Expanded(child: LogLines(widget.log))
+            ]));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/startupscreen.dart
+++ b/bruig/flutterui/bruig/lib/screens/startupscreen.dart
@@ -5,9 +5,9 @@ import 'package:provider/provider.dart';
 import 'package:bruig/theme_manager.dart';
 
 class StartupScreen extends StatelessWidget {
-  final Widget? child;
+  final List<Widget> widgetList;
   final bool? about;
-  const StartupScreen(this.child, {this.about = false, Key? key})
+  const StartupScreen(this.widgetList, {this.about = false, Key? key})
       : super(key: key);
 
   @override
@@ -35,30 +35,43 @@ class StartupScreen extends StatelessWidget {
                                       ? 0.25
                                       : 1))),
                   Container(
-                    decoration: isScreenSmall
-                        ? null
-                        : BoxDecoration(
-                            gradient: LinearGradient(
-                                begin: Alignment.bottomLeft,
-                                end: Alignment.topRight,
-                                colors: [
-                                theme.getTheme().canvasColor,
-                                theme.getTheme().backgroundColor,
-                                theme.getTheme().canvasColor.withOpacity(0.34),
-                              ],
-                                stops: const [
-                                0,
-                                0.17,
-                                1
-                              ])),
-                    padding: const EdgeInsets.all(30),
-                  ),
-                  Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [Expanded(child: Center(child: this.child))]),
+                      decoration: isScreenSmall
+                          ? null
+                          : BoxDecoration(
+                              gradient: LinearGradient(
+                                  begin: Alignment.bottomLeft,
+                                  end: Alignment.topRight,
+                                  colors: [
+                                  theme.getTheme().canvasColor,
+                                  theme.getTheme().backgroundColor,
+                                  theme
+                                      .getTheme()
+                                      .canvasColor
+                                      .withOpacity(0.34),
+                                ],
+                                  stops: const [
+                                  0,
+                                  0.17,
+                                  1
+                                ])),
+                      padding: const EdgeInsets.all(30),
+                      child: Center(
+                          child: ListView(
+                        shrinkWrap: true,
+                        children: [
+                          Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [...widgetList])
+                        ],
+                      ))),
                   about == null || about == false
-                      ? const Positioned(
-                          top: 10, left: 10, child: AboutButton())
+                      ? Positioned(
+                          top: 5,
+                          left: 5,
+                          child: SizedBox(
+                              height: isScreenSmall ? 70 : 100,
+                              width: isScreenSmall ? 70 : 100,
+                              child: const Center(child: AboutButton())))
                       : const Empty(),
                 ]))));
   }

--- a/bruig/flutterui/bruig/lib/screens/startupscreen.dart
+++ b/bruig/flutterui/bruig/lib/screens/startupscreen.dart
@@ -1,10 +1,14 @@
+import 'package:bruig/components/buttons.dart';
+import 'package:bruig/components/empty_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:bruig/theme_manager.dart';
 
 class StartupScreen extends StatelessWidget {
   final Widget? child;
-  const StartupScreen(this.child, {Key? key}) : super(key: key);
+  final bool? about;
+  const StartupScreen(this.child, {this.about = false, Key? key})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -31,27 +35,31 @@ class StartupScreen extends StatelessWidget {
                                       ? 0.25
                                       : 1))),
                   Container(
-                      decoration: isScreenSmall
-                          ? null
-                          : BoxDecoration(
-                              gradient: LinearGradient(
-                                  begin: Alignment.bottomLeft,
-                                  end: Alignment.topRight,
-                                  colors: [
-                                  theme.getTheme().canvasColor,
-                                  theme.getTheme().backgroundColor,
-                                  theme
-                                      .getTheme()
-                                      .canvasColor
-                                      .withOpacity(0.34),
-                                ],
-                                  stops: const [
-                                  0,
-                                  0.17,
-                                  1
-                                ])),
-                      padding: const EdgeInsets.all(30),
-                      child: this.child)
+                    decoration: isScreenSmall
+                        ? null
+                        : BoxDecoration(
+                            gradient: LinearGradient(
+                                begin: Alignment.bottomLeft,
+                                end: Alignment.topRight,
+                                colors: [
+                                theme.getTheme().canvasColor,
+                                theme.getTheme().backgroundColor,
+                                theme.getTheme().canvasColor.withOpacity(0.34),
+                              ],
+                                stops: const [
+                                0,
+                                0.17,
+                                1
+                              ])),
+                    padding: const EdgeInsets.all(30),
+                  ),
+                  Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [Expanded(child: Center(child: this.child))]),
+                  about == null || about == false
+                      ? const Positioned(
+                          top: 10, left: 10, child: AboutButton())
+                      : const Empty(),
                 ]))));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/unlock_ln.dart
+++ b/bruig/flutterui/bruig/lib/screens/unlock_ln.dart
@@ -115,86 +115,85 @@ class __LNUnlockPageState extends State<_LNUnlockPage> {
   @override
   Widget build(BuildContext context) {
     bool isScreenSmall = MediaQuery.of(context).size.width <= 500;
-    return StartupScreen(Consumer<ThemeNotifier>(
-      builder: (context, theme, _) {
-        return Column(children: [
-          const SetupScreenAbountButton(),
-          Text("Connect to Bison Relay",
-              style: TextStyle(
-                  color: theme.getTheme().dividerColor,
-                  fontSize: theme.getHugeFont(context),
-                  fontWeight: FontWeight.w200)),
-          SizedBox(height: isScreenSmall ? 8 : 34),
-          Column(children: [
-            SizedBox(
-                width: 377,
-                child: Text("Password",
-                    textAlign: TextAlign.left,
+    return Consumer<ThemeNotifier>(
+        builder: (context, theme, _) => StartupScreen(Column(
+              children: [
+                Text("Connect to Bison Relay",
                     style: TextStyle(
-                        color: theme.getTheme().indicatorColor,
-                        fontSize: theme.getMediumFont(context),
-                        fontWeight: FontWeight.w300))),
-            const SizedBox(height: 5),
-            Center(
-                child: SizedBox(
-                    width: 377,
-                    child: TextField(
-                        autofocus: true,
-                        cursorColor: theme.getTheme().indicatorColor,
-                        decoration: InputDecoration(
-                            errorText: _validate,
-                            border: InputBorder.none,
-                            hintText: "Password",
-                            hintStyle: TextStyle(
-                                fontSize: theme.getLargeFont(context),
-                                color: theme.getTheme().dividerColor),
-                            filled: true,
-                            fillColor: theme.getTheme().cardColor),
-                        style: TextStyle(
-                            color: theme.getTheme().indicatorColor,
-                            fontSize: theme.getLargeFont(context)),
-                        controller: passCtrl,
-                        obscureText: true,
-                        onSubmitted: (value) {
-                          if (!loading) {
-                            unlock();
-                          }
-                        },
-                        onChanged: (value) {
-                          setState(() {
-                            _validate =
-                                value.isEmpty ? "Password cannot be empty" : "";
-                          });
-                        }))),
-            SizedBox(height: isScreenSmall ? 8 : 34),
-            Center(
-                child: SizedBox(
-                    width: 283,
-                    child: Row(children: [
-                      const SizedBox(width: 35),
-                      LoadingScreenButton(
-                        onPressed: !loading ? unlock : null,
-                        text: "Unlock Wallet",
-                      ),
-                      const SizedBox(width: 10),
-                      loading
-                          ? SizedBox(
-                              height: 25,
-                              width: 25,
-                              child: CircularProgressIndicator(
-                                  value: null,
-                                  backgroundColor:
-                                      theme.getTheme().backgroundColor,
-                                  color: theme.getTheme().dividerColor,
-                                  strokeWidth: 2),
-                            )
-                          : const SizedBox(width: 25),
-                    ]))),
-          ]),
-          const Expanded(child: Empty()),
-        ]);
-      },
-    ));
+                        color: theme.getTheme().dividerColor,
+                        fontSize: theme.getHugeFont(context),
+                        fontWeight: FontWeight.w200)),
+                SizedBox(height: isScreenSmall ? 8 : 34),
+                Column(children: [
+                  SizedBox(
+                      width: 377,
+                      child: Text("Password",
+                          textAlign: TextAlign.left,
+                          style: TextStyle(
+                              color: theme.getTheme().indicatorColor,
+                              fontSize: theme.getMediumFont(context),
+                              fontWeight: FontWeight.w300))),
+                  const SizedBox(height: 5),
+                  Center(
+                      child: SizedBox(
+                          width: 377,
+                          child: TextField(
+                              autofocus: true,
+                              cursorColor: theme.getTheme().indicatorColor,
+                              decoration: InputDecoration(
+                                  errorText: _validate,
+                                  border: InputBorder.none,
+                                  hintText: "Password",
+                                  hintStyle: TextStyle(
+                                      fontSize: theme.getLargeFont(context),
+                                      color: theme.getTheme().dividerColor),
+                                  filled: true,
+                                  fillColor: theme.getTheme().cardColor),
+                              style: TextStyle(
+                                  color: theme.getTheme().indicatorColor,
+                                  fontSize: theme.getLargeFont(context)),
+                              controller: passCtrl,
+                              obscureText: true,
+                              onSubmitted: (value) {
+                                if (!loading) {
+                                  unlock();
+                                }
+                              },
+                              onChanged: (value) {
+                                setState(() {
+                                  _validate = value.isEmpty
+                                      ? "Password cannot be empty"
+                                      : "";
+                                });
+                              }))),
+                  SizedBox(height: isScreenSmall ? 8 : 34),
+                  Center(
+                      child: SizedBox(
+                          width: 283,
+                          child: Row(children: [
+                            const SizedBox(width: 35),
+                            LoadingScreenButton(
+                              onPressed: !loading ? unlock : null,
+                              text: "Unlock Wallet",
+                            ),
+                            const SizedBox(width: 10),
+                            loading
+                                ? SizedBox(
+                                    height: 25,
+                                    width: 25,
+                                    child: CircularProgressIndicator(
+                                        value: null,
+                                        backgroundColor:
+                                            theme.getTheme().backgroundColor,
+                                        color: theme.getTheme().dividerColor,
+                                        strokeWidth: 2),
+                                  )
+                                : const SizedBox(width: 25),
+                          ]))),
+                ]),
+                const Expanded(child: Empty()),
+              ],
+            )));
   }
 }
 
@@ -255,10 +254,8 @@ class _LNChainSyncPageState extends State<_LNChainSyncPage> {
   Widget build(BuildContext context) {
     bool isScreenSmall = MediaQuery.of(context).size.width <= 500;
 
-    return StartupScreen(Consumer<ThemeNotifier>(
-        builder: (context, theme, child) => Column(children: [
-              const SetupScreenAbountButton(),
-              const SizedBox(height: 39),
+    return Consumer<ThemeNotifier>(
+        builder: (context, theme, child) => StartupScreen(Column(children: [
               Text("Setting up Bison Relay",
                   style: TextStyle(
                       color: theme.getTheme().dividerColor,

--- a/bruig/flutterui/bruig/lib/screens/unlock_ln.dart
+++ b/bruig/flutterui/bruig/lib/screens/unlock_ln.dart
@@ -116,84 +116,78 @@ class __LNUnlockPageState extends State<_LNUnlockPage> {
   Widget build(BuildContext context) {
     bool isScreenSmall = MediaQuery.of(context).size.width <= 500;
     return Consumer<ThemeNotifier>(
-        builder: (context, theme, _) => StartupScreen(Column(
-              children: [
-                Text("Connect to Bison Relay",
+      builder: (context, theme, _) => StartupScreen(<Widget>[
+        Text("Connect to Bison Relay",
+            style: TextStyle(
+                color: theme.getTheme().dividerColor,
+                fontSize: theme.getHugeFont(context),
+                fontWeight: FontWeight.w200)),
+        SizedBox(height: isScreenSmall ? 8 : 34),
+        SizedBox(
+            width: 377,
+            child: Text("Password",
+                textAlign: TextAlign.left,
+                style: TextStyle(
+                    color: theme.getTheme().indicatorColor,
+                    fontSize: theme.getMediumFont(context),
+                    fontWeight: FontWeight.w300))),
+        const SizedBox(height: 5),
+        Center(
+            child: SizedBox(
+                width: 377,
+                child: TextField(
+                    autofocus: true,
+                    cursorColor: theme.getTheme().indicatorColor,
+                    decoration: InputDecoration(
+                        errorText: _validate,
+                        border: InputBorder.none,
+                        hintText: "Password",
+                        hintStyle: TextStyle(
+                            fontSize: theme.getLargeFont(context),
+                            color: theme.getTheme().dividerColor),
+                        filled: true,
+                        fillColor: theme.getTheme().cardColor),
                     style: TextStyle(
-                        color: theme.getTheme().dividerColor,
-                        fontSize: theme.getHugeFont(context),
-                        fontWeight: FontWeight.w200)),
-                SizedBox(height: isScreenSmall ? 8 : 34),
-                Column(children: [
-                  SizedBox(
-                      width: 377,
-                      child: Text("Password",
-                          textAlign: TextAlign.left,
-                          style: TextStyle(
-                              color: theme.getTheme().indicatorColor,
-                              fontSize: theme.getMediumFont(context),
-                              fontWeight: FontWeight.w300))),
-                  const SizedBox(height: 5),
-                  Center(
-                      child: SizedBox(
-                          width: 377,
-                          child: TextField(
-                              autofocus: true,
-                              cursorColor: theme.getTheme().indicatorColor,
-                              decoration: InputDecoration(
-                                  errorText: _validate,
-                                  border: InputBorder.none,
-                                  hintText: "Password",
-                                  hintStyle: TextStyle(
-                                      fontSize: theme.getLargeFont(context),
-                                      color: theme.getTheme().dividerColor),
-                                  filled: true,
-                                  fillColor: theme.getTheme().cardColor),
-                              style: TextStyle(
-                                  color: theme.getTheme().indicatorColor,
-                                  fontSize: theme.getLargeFont(context)),
-                              controller: passCtrl,
-                              obscureText: true,
-                              onSubmitted: (value) {
-                                if (!loading) {
-                                  unlock();
-                                }
-                              },
-                              onChanged: (value) {
-                                setState(() {
-                                  _validate = value.isEmpty
-                                      ? "Password cannot be empty"
-                                      : "";
-                                });
-                              }))),
-                  SizedBox(height: isScreenSmall ? 8 : 34),
-                  Center(
-                      child: SizedBox(
-                          width: 283,
-                          child: Row(children: [
-                            const SizedBox(width: 35),
-                            LoadingScreenButton(
-                              onPressed: !loading ? unlock : null,
-                              text: "Unlock Wallet",
-                            ),
-                            const SizedBox(width: 10),
-                            loading
-                                ? SizedBox(
-                                    height: 25,
-                                    width: 25,
-                                    child: CircularProgressIndicator(
-                                        value: null,
-                                        backgroundColor:
-                                            theme.getTheme().backgroundColor,
-                                        color: theme.getTheme().dividerColor,
-                                        strokeWidth: 2),
-                                  )
-                                : const SizedBox(width: 25),
-                          ]))),
-                ]),
-                const Expanded(child: Empty()),
-              ],
-            )));
+                        color: theme.getTheme().indicatorColor,
+                        fontSize: theme.getLargeFont(context)),
+                    controller: passCtrl,
+                    obscureText: true,
+                    onSubmitted: (value) {
+                      if (!loading) {
+                        unlock();
+                      }
+                    },
+                    onChanged: (value) {
+                      setState(() {
+                        _validate =
+                            value.isEmpty ? "Password cannot be empty" : "";
+                      });
+                    }))),
+        SizedBox(height: isScreenSmall ? 8 : 34),
+        Center(
+            child: SizedBox(
+                width: 283,
+                child: Row(children: [
+                  const SizedBox(width: 35),
+                  LoadingScreenButton(
+                    onPressed: !loading ? unlock : null,
+                    text: "Unlock Wallet",
+                  ),
+                  const SizedBox(width: 10),
+                  loading
+                      ? SizedBox(
+                          height: 25,
+                          width: 25,
+                          child: CircularProgressIndicator(
+                              value: null,
+                              backgroundColor: theme.getTheme().backgroundColor,
+                              color: theme.getTheme().dividerColor,
+                              strokeWidth: 2),
+                        )
+                      : const SizedBox(width: 25),
+                ]))),
+      ]),
+    );
   }
 }
 
@@ -255,7 +249,7 @@ class _LNChainSyncPageState extends State<_LNChainSyncPage> {
     bool isScreenSmall = MediaQuery.of(context).size.width <= 500;
 
     return Consumer<ThemeNotifier>(
-        builder: (context, theme, child) => StartupScreen(Column(children: [
+        builder: (context, theme, child) => StartupScreen([
               Text("Setting up Bison Relay",
                   style: TextStyle(
                       color: theme.getTheme().dividerColor,
@@ -363,7 +357,7 @@ class _LNChainSyncPageState extends State<_LNChainSyncPage> {
                               optionalTextColor: theme.getTheme().dividerColor))
                     ])),
               )
-            ])));
+            ]));
   }
 }
 

--- a/bruig/flutterui/bruig/lib/screens/verify_invite.dart
+++ b/bruig/flutterui/bruig/lib/screens/verify_invite.dart
@@ -58,39 +58,38 @@ class _VerifyInviteScreenState extends State<VerifyInviteScreen> {
   Widget buildFundsWidget(BuildContext context, InviteFunds funds) {
     if (redeemed != null) {
       var total = formatDCR(atomsToDCR(redeemed!.total));
-      return StartupScreen(Consumer<ThemeNotifier>(
-          builder: (context, theme, child) => Column(children: [
+      return Consumer<ThemeNotifier>(
+          builder: (context, theme, child) => StartupScreen([
                 Text("Redeemed $total on the following tx:",
                     style: TextStyle(color: theme.getTheme().dividerColor)),
                 Copyable(redeemed!.txid,
                     TextStyle(color: theme.getTheme().dividerColor)),
                 Text("The funds will be available after the tx is mined.",
                     style: TextStyle(color: theme.getTheme().dividerColor)),
-              ])));
+              ]));
     }
 
     if (redeeming) {
-      return StartupScreen(Consumer<ThemeNotifier>(
-          builder: (context, theme, child) => Text(
-              "Attempting to redeem funds...",
-              style: TextStyle(color: theme.getTheme().dividerColor))));
+      return Consumer<ThemeNotifier>(
+          builder: (context, theme, child) => StartupScreen([
+                Text("Attempting to redeem funds...",
+                    style: TextStyle(color: theme.getTheme().dividerColor))
+              ]));
     }
 
-    return StartupScreen(Consumer<ThemeNotifier>(
-        builder: (context, theme, child) => Column(children: [
-              Column(children: [
-                Text("This invite contains funds stored in the following UTXO:",
-                    style: TextStyle(color: theme.getTheme().dividerColor)),
-                Copyable("${funds.txid}:${funds.index}",
-                    TextStyle(color: theme.getTheme().dividerColor)),
-                Text("Attempt to redeem funds?",
-                    style: TextStyle(color: theme.getTheme().dividerColor)),
-              ]),
+    return Consumer<ThemeNotifier>(
+        builder: (context, theme, child) => StartupScreen([
+              Text("This invite contains funds stored in the following UTXO:",
+                  style: TextStyle(color: theme.getTheme().dividerColor)),
+              Copyable("${funds.txid}:${funds.index}",
+                  TextStyle(color: theme.getTheme().dividerColor)),
+              Text("Attempt to redeem funds?",
+                  style: TextStyle(color: theme.getTheme().dividerColor)),
               const SizedBox(height: 10),
               ElevatedButton(
                   onPressed: () => redeemFunds(context, funds),
                   child: const Text("Redeem Funds")),
-            ])));
+            ]));
   }
 
   @override
@@ -98,9 +97,8 @@ class _VerifyInviteScreenState extends State<VerifyInviteScreen> {
     var invite = ModalRoute.of(context)!.settings.arguments as Invitation;
 
     var errorColor = Colors.red;
-    return StartupScreen(Consumer<ThemeNotifier>(
-        builder: (context, theme, child) => Column(children: [
-              const Expanded(child: Empty()),
+    return Consumer<ThemeNotifier>(
+        builder: (context, theme, child) => StartupScreen([
               Text("Accept Invite",
                   style: TextStyle(
                       color: theme.getTheme().dividerColor,
@@ -137,6 +135,6 @@ class _VerifyInviteScreenState extends State<VerifyInviteScreen> {
                   onPressed: () => onDenyInvite(context),
                   child: const Text("Deny")),
               const Expanded(child: Empty()),
-            ])));
+            ]));
   }
 }

--- a/bruig/flutterui/bruig/lib/screens/verify_server.dart
+++ b/bruig/flutterui/bruig/lib/screens/verify_server.dart
@@ -27,9 +27,8 @@ class _VerifyServerScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return StartupScreen(Consumer<ThemeNotifier>(
-        builder: (context, theme, child) => Column(children: [
-              const SizedBox(height: 258),
+    return Consumer<ThemeNotifier>(
+        builder: (context, theme, child) => StartupScreen([
               Text("Accept Server Fingerprint",
                   style: TextStyle(
                       color: theme.getTheme().dividerColor,
@@ -51,7 +50,6 @@ class _VerifyServerScreen extends StatelessWidget {
                   onPressed: () => onAcceptServerCreds(context),
                   child: const Text("Accept")),
               Container(height: 10)
-            ])));
-    ;
+            ]));
   }
 }

--- a/bruig/flutterui/bruig/pubspec.lock
+++ b/bruig/flutterui/bruig/pubspec.lock
@@ -206,14 +206,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_foreground_service:
-    dependency: "direct main"
-    description:
-      name: flutter_foreground_service
-      sha256: e045aaad2af73bd44b52d2b38aa3684258c6e7005de4e8887aa192d2be084fa1
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.4.1"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:

--- a/bruig/flutterui/plugin/example/pubspec.lock
+++ b/bruig/flutterui/plugin/example/pubspec.lock
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: file_picker
-      sha256: "21145c9c268d54b1f771d8380c195d2d6f655e0567dc1ca2f9c134c02c819e0a"
+      sha256: "1bbf65dd997458a08b531042ec3794112a6c39c07c37ff22113d2e7e4f81d4e4"
       url: "https://pub.dev"
     source: hosted
-    version: "5.3.3"
+    version: "6.2.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -159,6 +159,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -171,34 +195,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.11.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   path_provider:
     dependency: transitive
     description:
@@ -296,18 +320,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -328,10 +352,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.1"
   typed_data:
     dependency: transitive
     description:
@@ -348,14 +372,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
+  vm_service:
     dependency: transitive
     description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "13.0.0"
   web_socket_channel:
     dependency: transitive
     description:
@@ -381,5 +405,5 @@ packages:
     source: hosted
     version: "1.0.2"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
-  flutter: ">=3.3.0"
+  dart: ">=3.2.0-0 <4.0.0"
+  flutter: ">=3.7.0"

--- a/bruig/flutterui/plugin/pubspec.lock
+++ b/bruig/flutterui/plugin/pubspec.lock
@@ -149,10 +149,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   convert:
     dependency: "direct main"
     description:
@@ -328,6 +328,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.7.1"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -348,26 +372,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.11.0"
   mime:
     dependency: transitive
     description:
@@ -388,10 +412,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   path_provider:
     dependency: "direct main"
     description:
@@ -529,18 +553,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   stream_transform:
     dependency: transitive
     description:
@@ -569,10 +593,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.1"
   timing:
     dependency: transitive
     description:
@@ -597,6 +621,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.0"
   watcher:
     dependency: transitive
     description:
@@ -605,14 +637,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.4-beta"
   web_socket_channel:
     dependency: "direct main"
     description:
@@ -646,5 +670,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.2.0-0 <4.0.0"
   flutter: ">=3.7.0"


### PR DESCRIPTION
Now for all screens that wish to use the "StartupScreen" as a template they can simply use a list of widgets as a parameter of StartupScreen and everything should be properly centered/spaced and resized for their particular usage.