### PR TITLE
bruig: Use reverse and resizeToAvoidBottomInset

### DIFF
--- a/bruig/flutterui/bruig/lib/components/chat/messages.dart
+++ b/bruig/flutterui/bruig/lib/components/chat/messages.dart
@@ -58,9 +58,10 @@ class _MessagesState extends State<Messages> {
                         : max)
                 .index
             : 0;
+        print("old maxItem $_maxItem newMaxItem $newMaxItem");
         if (mounted && newMaxItem != _maxItem) {
           _maxItem = newMaxItem;
-          if (_maxItem < chat.msgs.length - 5) {
+          if (_maxItem < 5) {
             setState(() {
               _showFAB = true;
             });
@@ -69,7 +70,7 @@ class _MessagesState extends State<Messages> {
               _showFAB = false;
             });
           }
-          if (_maxItem < chat.msgs.length - 2) {
+          if (_maxItem < 2) {
             chat.scrollPosition = newMaxItem;
           } else {
             chat.scrollPosition = 0;
@@ -78,8 +79,8 @@ class _MessagesState extends State<Messages> {
       });
     });
     chat.addListener(onChatChanged);
-    _maybeScrollToFirstUnread();
-    _maybeScrollToBottom();
+    //_maybeScrollToFirstUnread();
+    //_maybeScrollToBottom();
     _lastChat = chat;
   }
 
@@ -88,8 +89,8 @@ class _MessagesState extends State<Messages> {
     super.didUpdateWidget(oldWidget);
     oldWidget.chat.removeListener(onChatChanged);
     chat.addListener(onChatChanged);
-    _maybeScrollToFirstUnread();
-    _maybeScrollToBottom();
+    //_maybeScrollToFirstUnread();
+    //_maybeScrollToBottom();
     onChatChanged();
     _lastChat = chat;
   }
@@ -105,7 +106,7 @@ class _MessagesState extends State<Messages> {
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (mounted) {
         widget.itemScrollController.scrollTo(
-          index: chat.msgs.length - 1,
+          index: 0,
           alignment: 0.0,
           duration: const Duration(
               microseconds: 1), // a little bit smoother than a jump
@@ -172,50 +173,20 @@ class _MessagesState extends State<Messages> {
     var textColor = theme.dividerColor;
     var backgroundColor = theme.backgroundColor;
     return Scaffold(
+        resizeToAvoidBottomInset: true,
         floatingActionButton: _getFAB(textColor, backgroundColor),
-        body: PageStorage(
-          bucket: _pageStorageBucket,
-          child: SelectionArea(
+        body: SelectionArea(
+          child: PageStorage(
+            bucket: _pageStorageBucket,
             child: ScrollablePositionedList.builder(
+              reverse: true,
               key: PageStorageKey<String>('chat ${chat.nick}'),
-              itemCount:
-                  chat.isGC ? calculateTotalMessageCount() : chat.msgs.length,
+              itemCount: chat.msgs.length,
               physics: const ClampingScrollPhysics(),
-              itemBuilder: chat.isGC
-                  ? (context, index) {
-                      int count = 0;
-                      for (var dayGCMsgs in chat.dayGCMsgs) {
-                        if (index == count) {
-                          // This is a day change message
-                          return Row(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              DateChange(
-                                child: Text(
-                                  dayGCMsgs.date,
-                                  style: TextStyle(color: textColor),
-                                ),
-                              ),
-                            ],
-                          );
-                        }
-                        count++; // for the day change message
-                        if (index < count + dayGCMsgs.msgs.length) {
-                          var msg = dayGCMsgs.msgs[index - count];
-                          return Container(
-                            color: backgroundColor,
-                            child:
-                                Event(chat, msg, nick, client, _scrollToBottom),
-                          );
-                        }
-                        count += dayGCMsgs.msgs.length;
-                      }
-                      return const SizedBox.shrink();
-                    }
-                  : (context, index) {
-                      return Event(chat, chat.msgs[index], nick, client,
-                          _scrollToBottom);
-                    },
+              itemBuilder: (context, index) {
+                return Event(
+                    chat, chat.msgs[index], nick, client, _scrollToBottom);
+              },
               itemScrollController: widget.itemScrollController,
               itemPositionsListener: widget.itemPositionsListener,
             ),

--- a/bruig/flutterui/bruig/lib/components/chat/messages.dart
+++ b/bruig/flutterui/bruig/lib/components/chat/messages.dart
@@ -52,16 +52,15 @@ class _MessagesState extends State<Messages> {
                 .itemPositionsListener.itemPositions.value.isNotEmpty
             ? widget.itemPositionsListener.itemPositions.value
                 .where((ItemPosition position) => position.itemLeadingEdge < 1)
-                .reduce((ItemPosition max, ItemPosition position) =>
-                    position.itemLeadingEdge > max.itemLeadingEdge
-                        ? position
-                        : max)
-                .index
+                .reduce((ItemPosition max, ItemPosition position) {
+                return position.itemLeadingEdge < max.itemLeadingEdge
+                    ? position
+                    : max;
+              }).index
             : 0;
-        print("old maxItem $_maxItem newMaxItem $newMaxItem");
         if (mounted && newMaxItem != _maxItem) {
           _maxItem = newMaxItem;
-          if (_maxItem < 5) {
+          if (_maxItem > 5) {
             setState(() {
               _showFAB = true;
             });
@@ -70,7 +69,7 @@ class _MessagesState extends State<Messages> {
               _showFAB = false;
             });
           }
-          if (_maxItem < 2) {
+          if (_maxItem > 2) {
             chat.scrollPosition = newMaxItem;
           } else {
             chat.scrollPosition = 0;
@@ -79,8 +78,8 @@ class _MessagesState extends State<Messages> {
       });
     });
     chat.addListener(onChatChanged);
-    //_maybeScrollToFirstUnread();
-    //_maybeScrollToBottom();
+    _maybeScrollToFirstUnread();
+    _maybeScrollToBottom();
     _lastChat = chat;
   }
 
@@ -89,8 +88,8 @@ class _MessagesState extends State<Messages> {
     super.didUpdateWidget(oldWidget);
     oldWidget.chat.removeListener(onChatChanged);
     chat.addListener(onChatChanged);
-    //_maybeScrollToFirstUnread();
-    //_maybeScrollToBottom();
+    _maybeScrollToFirstUnread();
+    _maybeScrollToBottom();
     onChatChanged();
     _lastChat = chat;
   }

--- a/bruig/flutterui/bruig/lib/models/client.dart
+++ b/bruig/flutterui/bruig/lib/models/client.dart
@@ -218,8 +218,7 @@ class ChatModel extends ChangeNotifier {
         msg.firstUnread = true;
       }
     }
-    if (_msgs.isNotEmpty &&
-        _msgs[_msgs.length - 1].source?.nick == msg.source?.nick) {
+    if (_msgs.isNotEmpty && _msgs[0].source?.nick == msg.source?.nick) {
       msg.sameUser = true;
     }
 
@@ -228,13 +227,12 @@ class ChatModel extends ChangeNotifier {
     if (_msgs.isEmpty) {
       // If there are no messages yet, just show avatar on the new message
       msg.showAvatar = true;
-    } else if (_msgs.isNotEmpty &&
-        _msgs[_msgs.length - 1].source?.nick == msg.source?.nick) {
+    } else if (_msgs.isNotEmpty && _msgs[0].source?.nick == msg.source?.nick) {
       // If there are messages then check to see if the previous message has the
       // same or different nick; if same remove avatar from previous and add
       // to new message. If different then just showAvatar on the new message
       // and keep previous message set to true.
-      _msgs[msgs.length - 1].showAvatar = false;
+      _msgs[0].showAvatar = false;
       msg.showAvatar = true;
     } else if (_msgs.isNotEmpty &&
         _msgs[_msgs.length - 1].source?.nick != msg.source?.nick) {
@@ -870,8 +868,8 @@ class ClientModel extends ChangeNotifier {
       // If unreadMsgCount are both 0, then check last message timestamps;
       var bTimeStamp = 0;
       var aTimeStamp = 0;
-      var bLastMessage = b._msgs[b._msgs.length - 1];
-      var bLastMessageEvent = b._msgs[b._msgs.length - 1].event;
+      var bLastMessage = b._msgs[0];
+      var bLastMessageEvent = b._msgs[0].event;
       if (bLastMessageEvent is PM) {
         bTimeStamp = bLastMessage.source?.nick == null
             ? bLastMessageEvent.timestamp
@@ -882,8 +880,8 @@ class ClientModel extends ChangeNotifier {
             : bLastMessageEvent.timestamp * 1000;
       }
 
-      var aLastMessage = a._msgs[a._msgs.length - 1];
-      var aLastMessageEvent = a._msgs[a._msgs.length - 1].event;
+      var aLastMessage = a._msgs[0];
+      var aLastMessageEvent = a._msgs[0].event;
       if (aLastMessageEvent is PM) {
         aTimeStamp = aLastMessage.source?.nick == null
             ? aLastMessageEvent.timestamp

--- a/bruig/flutterui/bruig/lib/models/client.dart
+++ b/bruig/flutterui/bruig/lib/models/client.dart
@@ -112,7 +112,7 @@ class DayGCMessages {
   List<ChatEventModel> _msgs = [];
   UnmodifiableListView<ChatEventModel> get msgs => UnmodifiableListView(_msgs);
   void append(ChatEventModel msg) {
-    _msgs.add(msg);
+    _msgs.insert(0, msg);
   }
 
   String date = "";
@@ -259,7 +259,7 @@ class ChatModel extends ChangeNotifier {
         _msgs.add(ChatEventModel(dateChange, null));
       } else {
         var lastTimestamp = 0;
-        for (var i = _msgs.length - 1; i >= 0; i--) {
+        for (var i = 0; i < _msgs.length; i++) {
           var oldEvent = _msgs[i].event;
           if (oldEvent is PM) {
             lastTimestamp = _msgs[i].source?.nick == null
@@ -277,13 +277,12 @@ class ChatModel extends ChangeNotifier {
           var lastDate = DateChangeEvent(
               DateTime.fromMillisecondsSinceEpoch(lastTimestamp));
           if (lastDate.msg != dateChange.msg) {
-            _msgs.add(ChatEventModel(dateChange, null));
+            _msgs.insert(0, (ChatEventModel(dateChange, null)));
           }
         }
       }
     }
-
-    _msgs.add(msg);
+    _msgs.insert(0, msg);
     if (!history) {
       if (!_active) {
         if (msg.event is PM || msg.event is GCMsg) {
@@ -316,7 +315,7 @@ class ChatModel extends ChangeNotifier {
     bool dayFound = false;
     for (int i = 0; i < dayGCMsgs.length; i++) {
       if (dayGCMsgs[i].date == DateFormat("EEE - d MMM y").format(date)) {
-        dayGCMsgs[i]._msgs.add(msg);
+        dayGCMsgs[i]._msgs.insert(0, (msg));
         dayFound = true;
       }
     }
@@ -324,7 +323,7 @@ class ChatModel extends ChangeNotifier {
       var dayGCMsg = DayGCMessages();
       dayGCMsg._msgs = [msg];
       dayGCMsg.date = DateFormat("EEE - d MMM y").format(date);
-      _dayGCMsgs.add(dayGCMsg);
+      _dayGCMsgs.insert(0, dayGCMsg);
     }
   }
 
@@ -339,7 +338,7 @@ class ChatModel extends ChangeNotifier {
 
   void payTip(double amount) async {
     var tip = await Golib.payTip(id, amount);
-    _msgs.add(ChatEventModel(tip, this));
+    _msgs.insert(0, ChatEventModel(tip, this));
     notifyListeners();
   }
 
@@ -357,7 +356,7 @@ class ChatModel extends ChangeNotifier {
       if (_msgs.isNotEmpty && _msgs[_msgs.length - 1].source == null) {
         evnt.sameUser = true;
       }
-      _msgs.add(evnt);
+      _msgs.insert(0, (evnt));
 
       appendDayGCMsgs(evnt, DateTime.fromMillisecondsSinceEpoch(timestamp));
 
@@ -377,7 +376,7 @@ class ChatModel extends ChangeNotifier {
       if (_msgs.isNotEmpty && _msgs[_msgs.length - 1].source == null) {
         evnt.sameUser = true;
       }
-      _msgs.add(evnt);
+      _msgs.insert(0, evnt);
       notifyListeners();
 
       try {


### PR DESCRIPTION
Added these options to our ScrollPositionedList of messages to properly show the "end" of the chat immediately instead of always first showing the top then scrolling down.  

And now the chat should properly react to the virtual keyboard being shown/hidden.