### PR TITLE
brclient: add form field regexp

### DIFF
--- a/brclient/mainwindow.go
+++ b/brclient/mainwindow.go
@@ -307,6 +307,11 @@ func (mws mainWindowState) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					cw.selEl.formField != nil && cw.selEl.formField.typ == "submit" {
 
 					// Submit form.
+
+					if cw.formValidationError {
+						// Do something here?
+						break
+					}
 					uid := cw.page.UID
 					action := cw.selEl.form.action()
 


### PR DESCRIPTION
`txtinput` fields for pages that are given `regexp` and `regexpstr` arguments are now checked for correctness.  If any errors are shown then the submit button is now disabled until all errs are fixed.