### PR TITLE
brclient:  set an initial timeout checking balances.

### DIFF
--- a/brclient/appstate.go
+++ b/brclient/appstate.go
@@ -431,7 +431,8 @@ func (as *appState) recheckLNBalance() {
 func (as *appState) trackLNBalances() {
 	const minTimeout = 500 * time.Millisecond
 	const maxTimeout = 4 * time.Minute
-	var timeout time.Duration // Execute first check immediately
+	timeout := minTimeout
+
 	var lastBal balance
 	var checkedSetupNeeds bool
 	var lastUnconf dcrutil.Amount


### PR DESCRIPTION
This allows the backoff timer to work.