### PR TITLE
bruig: fix avif embed fallthrough and markdown image error handling

### DIFF
--- a/bruig/flutterui/bruig/lib/components/md_elements.dart
+++ b/bruig/flutterui/bruig/lib/components/md_elements.dart
@@ -493,15 +493,20 @@ class ImageMd extends StatelessWidget {
                 builder: (_) => ImageDialog(imgContent, type, name: name));
           },
           child: Container(
-            constraints: const BoxConstraints(maxHeight: 250, maxWidth: 250),
             margin: const EdgeInsets.symmetric(horizontal: 2, vertical: 2),
-            decoration: BoxDecoration(
+            child: ClipRRect(
               borderRadius: const BorderRadius.all(Radius.circular(8.0)),
-              image: DecorationImage(
-                image: MemoryImage(imgContent),
-                onError: (exception, stackTrace) {
-                  debugPrint("ImageMd unable to decode image: $exception");
-                },
+              child: ConstrainedBox(
+                constraints:
+                    const BoxConstraints(maxHeight: 250, maxWidth: 250),
+                child: Image.memory(
+                  imgContent,
+                  fit: BoxFit.contain,
+                  errorBuilder: (context, error, stackTrace) {
+                    debugPrint("ImageMd unable to decode image: $error");
+                    return const SizedBox.shrink();
+                  },
+                ),
               ),
             ),
           ),

--- a/bruig/flutterui/bruig/lib/components/md_elements.dart
+++ b/bruig/flutterui/bruig/lib/components/md_elements.dart
@@ -170,6 +170,7 @@ class EmbedInlineSyntax extends md.InlineSyntax {
           break;
         case "image/avif":
           tag = "avif";
+          break;
         case "text/plain":
           // Decode plain text directly.
           tag = "pre";


### PR DESCRIPTION
`EmbedInlineSyntax`'s mime-type switch is missing a `break` on the `image/avif` case, so it falls through into `text/plain`: the tag set to `"avif"` is immediately overwritten with `"pre"` and every avif embed renders as decoded plain text instead of an image.

The second commit replaces `ImageMd`'s `BoxDecoration`/`DecorationImage` with `ClipRRect` + `ConstrainedBox` + `Image.memory`. `DecorationImage.onError` can only report a decode failure, it cannot substitute a fallback, so a corrupt or unsupported image left the exception unhandled and surfaced as a red error box inside the chat or feed body. `Image.memory`'s `errorBuilder` lets it collapse to nothing instead. Same rounded corners and 250x250 bound as before, and it matches how chat and feed image embeds are already rendered elsewhere.

Two commits, reviewable separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
