### PR TITLE
bruig: give SecondarySideMenuList's list: rows a Material ancestor

### DIFF
--- a/bruig/flutterui/bruig/lib/components/containers.dart
+++ b/bruig/flutterui/bruig/lib/components/containers.dart
@@ -116,7 +116,18 @@ class SecondarySideMenuList extends StatelessWidget {
                         child: ListTileTheme.merge(
                             tileColor: theme.colors.surfaceContainerLowest,
                             // tileColor: Colors.amber,
-                            child: _child())),
+                            // ListTile.tileColor needs a nearby Material
+                            // ancestor to paint into and to render ink
+                            // splashes. `items:` callers get one per row via
+                            // SecondarySideMenuItem, but a caller passing
+                            // `list:` (a raw ListView of its own ListTiles)
+                            // does not, so the tileColor set just above never
+                            // reaches those rows. MaterialType.transparency
+                            // paints nothing itself, so it supplies that
+                            // ancestor without changing appearance.
+                            child: Material(
+                                type: MaterialType.transparency,
+                                child: _child()))),
                     ...(footer != null ? [footer!] : []),
                   ]),
             ));


### PR DESCRIPTION
`SecondarySideMenuList` sets a `tileColor` for its rows via `ListTileTheme.merge`, but `ListTile` needs a nearby `Material` ancestor to paint that color into and to render its ink splashes.

The `items:` path gets one per row from `SecondarySideMenuItem`, which wraps each child in a `Material`. The `list:` path — a caller-supplied `ListView` of its own `ListTile`s, used by Settings, the chat list and LN management — gets none, so the configured `tileColor` never reaches those rows and taps produce no ink splash.

This wraps `ListTileTheme.merge`'s child in a `MaterialType.transparency` `Material` so both paths behave the same. Transparency paints nothing of its own, so nothing changes visually beyond the rows that were already meant to be colored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
