### PR TITLE
bruig: don't crash when a GC list update races with leaving the GC

### DIFF
--- a/bruig/flutterui/bruig/lib/models/client.dart
+++ b/bruig/flutterui/bruig/lib/models/client.dart
@@ -1406,8 +1406,15 @@ class ClientModel extends ChangeNotifier {
   void _handleGCListUpdates() async {
     var stream = Golib.gcListUpdates();
     await for (var update in stream) {
-      // Force creating the chat if it doesn't exist.
-      _newChat(update.id, update.name, true);
+      // Force creating the chat if it doesn't exist. Ignore errors: the
+      // update may race with the GC being left/removed locally, in which
+      // case Golib.getGC() (called from _newChat) fails with "entry not
+      // found" and there's nothing to create a chat for anymore.
+      try {
+        await _newChat(update.id, update.name, true);
+      } catch (exception) {
+        // Ignore.
+      }
     }
   }
 


### PR DESCRIPTION
`_handleGCListUpdates` calls `_newChat` for every incoming update, which in turn calls `Golib.getGC()`. If an update arrives just after the GC has been left or removed locally, that lookup fails with `entry not found` and the exception propagates out of the `await for` handler, killing the subscription — so all subsequent GC list updates stop arriving for the rest of the session.

Await the call and ignore the failure: if the GC is already gone there is nothing left to create a chat for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
