### PR TITLE
bruig: don't re-push OverviewScreen when it is already mounted

### DIFF
--- a/bruig/flutterui/bruig/lib/main.dart
+++ b/bruig/flutterui/bruig/lib/main.dart
@@ -455,10 +455,18 @@ class _AppState extends State<App> with WindowListener {
     var rtc = Provider.of<RealtimeChatModel>(context, listen: false);
 
     await client.readAddressBook();
-    navkey.currentState?.pushNamedAndRemoveUntil(OverviewScreen.routeName,
-        (route) {
-      return false;
-    });
+    // Skip re-pushing Overview if it's already mounted (e.g. a
+    // resumed-from-background call into addressBookLoaded(true) above): the
+    // route below would need to survive its exit transition before
+    // Navigator removes it, so a fresh OverviewScreen would briefly coexist
+    // with the still-mounted one, and both share static GlobalKeys
+    // (scaffoldKey/overviewNavKey), tripping "Duplicate GlobalKey".
+    if (scaffoldKey.currentState == null) {
+      navkey.currentState?.pushNamedAndRemoveUntil(OverviewScreen.routeName,
+          (route) {
+        return false;
+      });
+    }
     await doWalletChecks(wasAlreadyRunning);
     await client.fetchNetworkInfo();
     await client.fetchMyAvatar();


### PR DESCRIPTION
`pushNamedAndRemoveUntil` is called unconditionally after the address book loads, including on a resumed-from-background path where `OverviewScreen` is already on screen.

The outgoing route has to finish its exit transition before `Navigator` removes it, so for the length of that transition a fresh `OverviewScreen` coexists with the still-mounted one — and both reference the same static `scaffoldKey`/`overviewNavKey`, tripping Flutter's `Duplicate GlobalKey detected in widget tree` and leaving the app in a broken state.

This skips the push when Overview is already mounted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
