### PR TITLE
client: re-request file metadata for downloads restarted without it

### DIFF
--- a/client/client_content.go
+++ b/client/client_content.go
@@ -1176,6 +1176,20 @@ func (c *Client) restartDownloads(ctx context.Context) error {
 			continue
 		}
 
+		if fd.Metadata == nil {
+			// We restarted before receiving the metadata reply for
+			// this download (e.g. process died between StartFileDownload
+			// and handleFTGetReply). Re-send the metadata request instead
+			// of attempting to download chunks we can't yet describe.
+			rmftg := rpc.RMFTGet{FileID: fd.FID.String()}
+			payEvent := fmt.Sprintf("ftget.%s", fd.FID.ShortLogID())
+			if err := c.sendWithSendQ(payEvent, rmftg, fd.UID); err != nil {
+				ru.log.Errorf("Unable to re-request metadata of file %s: %v",
+					fd.FID, err)
+			}
+			continue
+		}
+
 		// Start to re-process the download.
 		go func() {
 			err := c.downloadChunks(ru, fd)


### PR DESCRIPTION
`restartDownloads` hands every outstanding download straight to `downloadChunks`, which rejects any whose `Metadata` is still nil with `unable to start download with nil metadata`. Nothing else re-requests that metadata, so a download interrupted between `StartFileDownload` and `handleFTGetReply` — i.e. the process died before the metadata reply arrived — logs that same error on every subsequent restart and can never make progress again.

This re-sends the `RMFTGet` metadata request for those downloads instead, using the same request and `payEvent` form `StartFileDownload` uses, so the download resumes once the reply comes back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
